### PR TITLE
GeoIP2 -> IPInfo 서비스 변경

### DIFF
--- a/src/main/java/page/clab/api/domain/book/dao/BookLoanRecordRepositoryImpl.java
+++ b/src/main/java/page/clab/api/domain/book/dao/BookLoanRecordRepositoryImpl.java
@@ -34,6 +34,7 @@ public class BookLoanRecordRepositoryImpl implements BookLoanRecordRepositoryCus
         List<BookLoanRecordResponseDto> results = queryFactory
                 .select(Projections.constructor(
                         BookLoanRecordResponseDto.class,
+                        bookLoanRecord.id,
                         bookLoanRecord.book.id,
                         bookLoanRecord.book.title,
                         bookLoanRecord.book.imageUrl,

--- a/src/main/java/page/clab/api/domain/book/dto/response/BookLoanRecordResponseDto.java
+++ b/src/main/java/page/clab/api/domain/book/dto/response/BookLoanRecordResponseDto.java
@@ -12,6 +12,8 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class BookLoanRecordResponseDto {
 
+    private Long bookLoanRecordId;
+
     private Long bookId;
 
     private String bookTitle;

--- a/src/main/java/page/clab/api/domain/login/application/LoginAttemptLogService.java
+++ b/src/main/java/page/clab/api/domain/login/application/LoginAttemptLogService.java
@@ -24,7 +24,7 @@ public class LoginAttemptLogService {
     @Transactional
     public void createLoginAttemptLog(HttpServletRequest request, String memberId, LoginAttemptResult loginAttemptResult) {
         String clientIpAddress = HttpReqResUtil.getClientIpAddressIfServletRequestExist();
-        IPResponse ipResponse = IPInfoUtil.getIpInfo(request);
+        IPResponse ipResponse = HttpReqResUtil.isLocalRequest(clientIpAddress) ? null : IPInfoUtil.getIpInfo(request);
         LoginAttemptLog loginAttemptLog = LoginAttemptLog.create(memberId, request, clientIpAddress, ipResponse, loginAttemptResult);
         loginAttemptLogRepository.save(loginAttemptLog);
     }

--- a/src/main/java/page/clab/api/domain/login/application/LoginAttemptLogService.java
+++ b/src/main/java/page/clab/api/domain/login/application/LoginAttemptLogService.java
@@ -13,7 +13,7 @@ import page.clab.api.domain.login.domain.LoginAttemptResult;
 import page.clab.api.domain.login.dto.response.LoginAttemptLogResponseDto;
 import page.clab.api.global.common.dto.PagedResponseDto;
 import page.clab.api.global.util.HttpReqResUtil;
-import page.clab.api.global.util.IpInfoUtil;
+import page.clab.api.global.util.IPInfoUtil;
 
 @Service
 @RequiredArgsConstructor
@@ -24,7 +24,7 @@ public class LoginAttemptLogService {
     @Transactional
     public void createLoginAttemptLog(HttpServletRequest request, String memberId, LoginAttemptResult loginAttemptResult) {
         String clientIpAddress = HttpReqResUtil.getClientIpAddressIfServletRequestExist();
-        IPResponse ipResponse = IpInfoUtil.getIpInfo(request);
+        IPResponse ipResponse = IPInfoUtil.getIpInfo(request);
         LoginAttemptLog loginAttemptLog = LoginAttemptLog.create(memberId, request, clientIpAddress, ipResponse, loginAttemptResult);
         loginAttemptLogRepository.save(loginAttemptLog);
     }

--- a/src/main/java/page/clab/api/domain/login/domain/LoginAttemptLog.java
+++ b/src/main/java/page/clab/api/domain/login/domain/LoginAttemptLog.java
@@ -48,7 +48,7 @@ public class LoginAttemptLog extends BaseEntity {
                 .memberId(memberId)
                 .userAgent(httpServletRequest.getHeader("User-Agent"))
                 .ipAddress(ipAddress)
-                .location(ipResponse == null ? "Unknown" : ipResponse.getCountryName() + " " + ipResponse.getRegion() + " " + ipResponse.getCity())
+                .location(ipResponse == null ? "Unknown" : ipResponse.getCity())
                 .loginAttemptResult(loginAttemptResult)
                 .loginAttemptTime(LocalDateTime.now())
                 .build();

--- a/src/main/java/page/clab/api/global/auth/filter/IpAuthenticationFilter.java
+++ b/src/main/java/page/clab/api/global/auth/filter/IpAuthenticationFilter.java
@@ -1,7 +1,10 @@
 package page.clab.api.global.auth.filter;
 
+import io.ipinfo.api.IPinfo;
+import io.ipinfo.api.errors.RateLimitedException;
 import io.ipinfo.api.model.IPResponse;
 import io.ipinfo.spring.strategies.attribute.AttributeStrategy;
+import io.ipinfo.spring.strategies.interceptor.InterceptorStrategy;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
@@ -11,6 +14,8 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import page.clab.api.global.config.IPInfoConfig;
+import page.clab.api.global.util.HttpReqResUtil;
 
 import java.io.IOException;
 
@@ -18,28 +23,56 @@ import java.io.IOException;
 @Slf4j
 public class IpAuthenticationFilter implements Filter {
 
+    private final IPinfo ipInfo;
+
     private final AttributeStrategy attributeStrategy;
 
-    public IpAuthenticationFilter(AttributeStrategy attributeStrategy) {
-        this.attributeStrategy = attributeStrategy;
+    private final InterceptorStrategy interceptorStrategy;
+
+    public IpAuthenticationFilter(IPInfoConfig ipInfoConfig) {
+        ipInfo = ipInfoConfig.ipInfo();
+        attributeStrategy = ipInfoConfig.attributeStrategy();
+        interceptorStrategy = ipInfoConfig.interceptorStrategy();
     }
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        IPResponse ipResponse = attributeStrategy.getAttribute((HttpServletRequest) request);
-        if (ipResponse == null) {
-            log.warn("No IP information found in the request.");
-            chain.doFilter(request, response);
-            return;
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        String clientIpAddress = HttpReqResUtil.getClientIpAddressIfServletRequestExist();
+        try {
+            if (shouldProcessRequest(httpRequest, clientIpAddress)) {
+                chain.doFilter(request, response);
+                return;
+            }
+            IPResponse ipResponse = storeIpInformation(clientIpAddress, httpRequest);
+            if (isNonPermittedCountry(ipResponse)) {
+                log.warn("Access from non-permitted country: {}", ipResponse.getCountryCode());
+                return;
+            }
+        } catch (RateLimitedException e) {
+            log.error("Rate limit exceeded while getting IP information.");
+        } catch (Exception e) {
+            log.error("Failed to get IP information.");
         }
-
-        String country = ipResponse.getCountryCode();
-        if (country != null && !country.equals("KR")) {
-            log.warn("Access from non-permitted country: {}", country);
-            return;
-        }
-
         chain.doFilter(request, response);
+    }
+
+    private boolean shouldProcessRequest(HttpServletRequest httpRequest, String clientIpAddress) {
+        return !interceptorStrategy.shouldRun(httpRequest)
+                || attributeStrategy.hasAttribute(httpRequest)
+                || HttpReqResUtil.isLocalRequest(clientIpAddress)
+                || clientIpAddress.equals("0.0.0.0");
+    }
+
+    private IPResponse storeIpInformation(String clientIpAddress, HttpServletRequest httpRequest) throws RateLimitedException {
+        IPResponse ipResponse = ipInfo.lookupIP(clientIpAddress);
+        attributeStrategy.storeAttribute(httpRequest, ipResponse);
+        return ipResponse;
+    }
+
+    private boolean isNonPermittedCountry(IPResponse ipResponse) {
+        String country = ipResponse.getCountryCode();
+        return country != null && !country.equals("KR");
     }
 
     @Override

--- a/src/main/java/page/clab/api/global/auth/filter/IpAuthenticationFilter.java
+++ b/src/main/java/page/clab/api/global/auth/filter/IpAuthenticationFilter.java
@@ -11,7 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import page.clab.api.global.util.HttpReqResUtil;
-import page.clab.api.global.util.IpInfoUtil;
+import page.clab.api.global.util.IPInfoUtil;
 
 import java.io.IOException;
 
@@ -22,7 +22,7 @@ public class IpAuthenticationFilter implements Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         String ipAddress = HttpReqResUtil.getClientIpAddressIfServletRequestExist();
-        IPResponse ipResponse = IpInfoUtil.getIpInfo((HttpServletRequest) request);
+        IPResponse ipResponse = IPInfoUtil.getIpInfo((HttpServletRequest) request);
         String country = ipResponse == null ? null : ipResponse.getCountryCode();
         if (country != null && !country.equals("KR")) {
             log.info("[{}:{}] 허용되지 않은 국가로부터의 접근입니다.", ipAddress, country);

--- a/src/main/java/page/clab/api/global/auth/filter/IpAuthenticationFilter.java
+++ b/src/main/java/page/clab/api/global/auth/filter/IpAuthenticationFilter.java
@@ -21,12 +21,14 @@ public class IpAuthenticationFilter implements Filter {
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        String ipAddress = HttpReqResUtil.getClientIpAddressIfServletRequestExist();
-        IPResponse ipResponse = IPInfoUtil.getIpInfo((HttpServletRequest) request);
-        String country = ipResponse == null ? null : ipResponse.getCountryCode();
-        if (country != null && !country.equals("KR")) {
-            log.info("[{}:{}] 허용되지 않은 국가로부터의 접근입니다.", ipAddress, country);
-            return;
+        String clientIpAddress = HttpReqResUtil.getClientIpAddressIfServletRequestExist();
+        if (!HttpReqResUtil.isLocalRequest(clientIpAddress)) {
+            IPResponse ipResponse = IPInfoUtil.getIpInfo((HttpServletRequest) request);
+            String country = ipResponse == null ? null : ipResponse.getCountryCode();
+            if (country != null && !country.equals("KR")) {
+                log.info("[{}:{}] 허용되지 않은 국가로부터의 접근입니다.", clientIpAddress, country);
+                return;
+            }
         }
         chain.doFilter(request, response);
     }

--- a/src/main/java/page/clab/api/global/common/dto/IPInfoResponse.java
+++ b/src/main/java/page/clab/api/global/common/dto/IPInfoResponse.java
@@ -5,7 +5,7 @@ import lombok.Setter;
 
 @Setter
 @Getter
-public class IpInfoResponse {
+public class IPInfoResponse {
 
     private String ip;
 

--- a/src/main/java/page/clab/api/global/config/IPInfoConfig.java
+++ b/src/main/java/page/clab/api/global/config/IPInfoConfig.java
@@ -5,6 +5,8 @@ import io.ipinfo.spring.IPinfoSpring;
 import io.ipinfo.spring.strategies.attribute.AttributeStrategy;
 import io.ipinfo.spring.strategies.attribute.SessionAttributeStrategy;
 import io.ipinfo.spring.strategies.interceptor.BotInterceptorStrategy;
+import io.ipinfo.spring.strategies.interceptor.InterceptorStrategy;
+import io.ipinfo.spring.strategies.ip.IPStrategy;
 import io.ipinfo.spring.strategies.ip.XForwardedForIPStrategy;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,11 +26,26 @@ public class IPInfoConfig {
     @Bean
     public IPinfoSpring ipinfoSpring() {
         return new IPinfoSpring.Builder()
-                .setIPinfo(new IPinfo.Builder().setToken(accessToken).build())
-                .interceptorStrategy(new BotInterceptorStrategy())
-                .ipStrategy(new XForwardedForIPStrategy())
+                .setIPinfo(ipInfo())
+                .interceptorStrategy(interceptorStrategy())
+                .ipStrategy(ipStrategy())
                 .attributeStrategy(attributeStrategy())
                 .build();
+    }
+
+    @Bean
+    public IPinfo ipInfo() {
+        return new IPinfo.Builder().setToken(accessToken).build();
+    }
+
+    @Bean
+    public InterceptorStrategy interceptorStrategy() {
+        return new BotInterceptorStrategy();
+    }
+
+    @Bean
+    public IPStrategy ipStrategy() {
+        return new XForwardedForIPStrategy();
     }
 
     @Bean

--- a/src/main/java/page/clab/api/global/config/IPInfoConfig.java
+++ b/src/main/java/page/clab/api/global/config/IPInfoConfig.java
@@ -6,15 +6,20 @@ import io.ipinfo.spring.strategies.attribute.AttributeStrategy;
 import io.ipinfo.spring.strategies.attribute.SessionAttributeStrategy;
 import io.ipinfo.spring.strategies.interceptor.BotInterceptorStrategy;
 import io.ipinfo.spring.strategies.ip.XForwardedForIPStrategy;
+import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
 
+@Getter
 @Configuration
 public class IPInfoConfig {
 
+    private final RestClient restClient = RestClient.create("https://ipinfo.io/");
+
     @Value("${ipinfo.access-token}")
-    private static String accessToken;
+    private String accessToken;
 
     @Bean
     public IPinfoSpring ipinfoSpring() {
@@ -29,10 +34,6 @@ public class IPInfoConfig {
     @Bean
     public AttributeStrategy attributeStrategy() {
         return new SessionAttributeStrategy();
-    }
-
-    public String getAccessToken() {
-        return accessToken;
     }
 
 }

--- a/src/main/java/page/clab/api/global/config/IPInfoConfig.java
+++ b/src/main/java/page/clab/api/global/config/IPInfoConfig.java
@@ -27,7 +27,7 @@ public class IPInfoConfig {
                 .setIPinfo(new IPinfo.Builder().setToken(accessToken).build())
                 .interceptorStrategy(new BotInterceptorStrategy())
                 .ipStrategy(new XForwardedForIPStrategy())
-                .attributeStrategy(new SessionAttributeStrategy())
+                .attributeStrategy(attributeStrategy())
                 .build();
     }
 

--- a/src/main/java/page/clab/api/global/config/SecurityConfig.java
+++ b/src/main/java/page/clab/api/global/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package page.clab.api.global.config;
 
-import io.ipinfo.spring.strategies.attribute.AttributeStrategy;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -63,7 +62,7 @@ public class SecurityConfig {
 
     private final OpenApiPatternsProperties OpenApiPatternsProperties;
 
-    private final AttributeStrategy attributeStrategy;
+    private final IPInfoConfig ipInfoConfig;
 
     @Value("${resource.file.url}")
     String fileURL;
@@ -82,7 +81,7 @@ public class SecurityConfig {
                 .authorizeRequests(this::configureRequests)
                 .authenticationProvider(authenticationConfig.authenticationProvider())
                 .addFilterBefore(
-                        new IpAuthenticationFilter(attributeStrategy),
+                        new IpAuthenticationFilter(ipInfoConfig),
                         UsernamePasswordAuthenticationFilter.class
                 )
                 .addFilterBefore(

--- a/src/main/java/page/clab/api/global/config/SecurityConfig.java
+++ b/src/main/java/page/clab/api/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package page.clab.api.global.config;
 
+import io.ipinfo.spring.strategies.attribute.AttributeStrategy;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -62,6 +63,8 @@ public class SecurityConfig {
 
     private final OpenApiPatternsProperties OpenApiPatternsProperties;
 
+    private final AttributeStrategy attributeStrategy;
+
     @Value("${resource.file.url}")
     String fileURL;
 
@@ -79,7 +82,7 @@ public class SecurityConfig {
                 .authorizeRequests(this::configureRequests)
                 .authenticationProvider(authenticationConfig.authenticationProvider())
                 .addFilterBefore(
-                        new IpAuthenticationFilter(),
+                        new IpAuthenticationFilter(attributeStrategy),
                         UsernamePasswordAuthenticationFilter.class
                 )
                 .addFilterBefore(

--- a/src/main/java/page/clab/api/global/config/WebConfig.java
+++ b/src/main/java/page/clab/api/global/config/WebConfig.java
@@ -1,7 +1,6 @@
 package page.clab.api.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.ipinfo.spring.IPinfoSpring;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,9 +28,6 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Autowired
     private ApiLoggingInterceptor apiLoggingInterceptor;
-
-    @Autowired
-    private IPinfoSpring ipinfoSpring;
 
     @Value("${resource.file.path}")
     private String filePath;
@@ -67,7 +63,6 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(ipinfoSpring);
         registry.addInterceptor(apiLoggingInterceptor);
     }
 

--- a/src/main/java/page/clab/api/global/util/HttpReqResUtil.java
+++ b/src/main/java/page/clab/api/global/util/HttpReqResUtil.java
@@ -4,7 +4,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
+import java.util.Set;
+
 public class HttpReqResUtil {
+
+    private static final Set<String> localIpSet = Set.of("0:0:0:0:0:0:0:1", "127.0.0.1", "192.168.0.1");
 
     private static final String[] IP_HEADER_CANDIDATES = {
             "X-Forwarded-For",
@@ -27,12 +31,15 @@ public class HttpReqResUtil {
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
         for (String header : IP_HEADER_CANDIDATES) {
             String ipList = request.getHeader(header);
-            if (ipList != null && ipList.length() != 0 && !"unknown".equalsIgnoreCase(ipList)) {
-                String ip = ipList.split(",")[0];
-                return ip;
+            if (ipList != null && !ipList.isEmpty() && !"unknown".equalsIgnoreCase(ipList)) {
+                return ipList.split(",")[0];
             }
         }
         return request.getRemoteAddr();
+    }
+
+    public static boolean isLocalRequest(String ipAddress) {
+        return localIpSet.contains(ipAddress);
     }
 
 }

--- a/src/main/java/page/clab/api/global/util/IPInfoUtil.java
+++ b/src/main/java/page/clab/api/global/util/IPInfoUtil.java
@@ -4,40 +4,39 @@ import io.ipinfo.api.model.IPResponse;
 import io.ipinfo.spring.strategies.attribute.AttributeStrategy;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
-import page.clab.api.global.common.dto.IpInfoResponse;
+import page.clab.api.global.common.dto.IPInfoResponse;
 import page.clab.api.global.config.IPInfoConfig;
 
 @Slf4j
 @Component
-public class IpInfoUtil {
+public class IPInfoUtil {
 
-    private static final RestClient restClient = RestClient.create();
-
-    private static final String IPINFO_BASE_URL = "https://ipinfo.io/";
+    private static RestClient restClient;
 
     private static String accessToken;
 
     private static AttributeStrategy attributeStrategy;
 
-    public IpInfoUtil(IPInfoConfig ipInfoConfig) {
+    public IPInfoUtil(IPInfoConfig ipInfoConfig) {
+        restClient = ipInfoConfig.getRestClient();
         accessToken = ipInfoConfig.getAccessToken();
-        IpInfoUtil.attributeStrategy = ipInfoConfig.attributeStrategy();
+        IPInfoUtil.attributeStrategy = ipInfoConfig.attributeStrategy();
     }
 
-    public static IpInfoResponse getIpInfo(String ipAddress) {
+    public static IPInfoResponse getIpInfo(String ipAddress) {
         return restClient.get()
-                .uri(IPINFO_BASE_URL + ipAddress + "?token=" + accessToken)
+                .uri(ipAddress)
+                .header("Authorization", "Bearer " + accessToken)
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .onStatus(HttpStatusCode::is4xxClientError, ((request, response) -> {
                     log.warn("4xx error occurred while getting ip info. Status code: {}", response.getStatusCode());
                 }))
-                .body(IpInfoResponse.class);
+                .body(IPInfoResponse.class);
     }
 
     public static IPResponse getIpInfo(HttpServletRequest request) {


### PR DESCRIPTION
## Summary

> 기존 GeoIP2 데이터베이스가 다소 부정확한 위치 정보를 반환하여 IPInfo로 서비스를 변경합니다.
매월 5만 건을 무료로 요청할 수 있으며, 초과될 경우 자동으로 위치 조회를 멈추게 설계되었습니다.

## Tasks

- GeoIP2 -> IPInfo 서비스 변경

## ETC

## Screenshot

