### PR TITLE
도서 리뷰 링크가 없을 경우 빈 배열을 반환하도록 변경 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/book/dto/request/BookRequestDto.java
+++ b/src/main/java/page/clab/api/domain/book/dto/request/BookRequestDto.java
@@ -41,7 +41,7 @@ public class BookRequestDto {
                 .author(requestDto.getAuthor())
                 .publisher(requestDto.getPublisher())
                 .imageUrl(requestDto.getImageUrl())
-                .reviewLinks(requestDto.reviewLinks)
+                .reviewLinks(requestDto.reviewLinks == null ? List.of() : requestDto.reviewLinks)
                 .build();
     }
 


### PR DESCRIPTION
## Summary

> reviewLinks가 null일 때 프론트엔드에서 일부 기능에 대한 문제가 발견됨.
프론트엔드에서 수정을 해도 무방하지만, 되도록 null을 반환하지 않는 것이 좋다고 판단되어 수정함.

## Tasks

- 도서 등록시 리뷰 링크 정보가 없을 경우 빈 배열을 저장하도록 변경

## ETC

## Screenshot

![image](https://github.com/KGU-C-Lab/clab-server/assets/85067003/37a1ed51-fc72-46fa-86c3-1ed6348d83a4)
![image](https://github.com/KGU-C-Lab/clab-server/assets/85067003/95150a87-eb45-4229-9c12-edbb6fd54b07)
