### PR TITLE
슬랙 에러 메시지 전송 오류 수정 완료

### DIFF
--- a/src/main/java/page/clab/api/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/page/clab/api/global/handler/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import jakarta.validation.ConstraintViolationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -67,6 +68,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.concurrent.CompletionException;
 
 @RestControllerAdvice(basePackages = "page.clab.api")
 @RequiredArgsConstructor
@@ -169,11 +171,14 @@ public class GlobalExceptionHandler {
             IllegalStateException.class,
             FileUploadFailException.class,
             DataIntegrityViolationException.class,
+            IncorrectResultSizeDataAccessException.class,
+            ArrayIndexOutOfBoundsException.class,
             IOException.class,
             WebClientRequestException.class,
             TransactionSystemException.class,
             SecurityException.class,
             CustomOptimisticLockingFailureException.class,
+            CompletionException.class,
             EncryptionException.class,
             DecryptionException.class,
             Exception.class


### PR DESCRIPTION
## Summary

> #325

일부 서버 에러에서 슬랙 메시지 전송에 실패하는 문제를 해결합니다.

## Tasks

- ExceptionHandler에 문제가 되던 서버 에러를 추가
- 일부 예외의 파싱 과정에서 발생하는 오류 수정
- 메시지가 정상적으로 보내지지 않던 오류 수정

## ETC

## Screenshot
![image](https://github.com/KGU-C-Lab/clab-server/assets/85067003/040b2eb6-d8af-41b3-95de-f9dc3b2034ed)

