### PR TITLE
내 댓글 조회시 발생하는 오류 수정 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/comment/application/CommentService.java
+++ b/src/main/java/page/clab/api/domain/comment/application/CommentService.java
@@ -26,6 +26,8 @@ import page.clab.api.global.exception.NotFoundException;
 import page.clab.api.global.exception.PermissionDeniedException;
 import page.clab.api.global.validation.ValidationService;
 
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Service
@@ -65,8 +67,12 @@ public class CommentService {
     public PagedResponseDto<CommentMyResponseDto> getMyComments(Pageable pageable) {
         Member currentMember = memberService.getCurrentMember();
         Page<Comment> comments = getCommentByWriter(currentMember, pageable);
-        Page<CommentMyResponseDto> commentDtos = comments.map(comment -> toCommentMyResponseDto(comment, currentMember));
-        return new PagedResponseDto<>(commentDtos);
+        List<CommentMyResponseDto> dtos = comments
+                .map(comment -> toCommentMyResponseDto(comment, currentMember))
+                .stream()
+                .filter(Objects::nonNull)
+                .toList();
+        return new PagedResponseDto<>(dtos, pageable, dtos.size());
     }
 
     @Transactional(readOnly = true)
@@ -167,7 +173,7 @@ public class CommentService {
     }
 
     private CommentMyResponseDto toCommentMyResponseDto(Comment comment, Member currentMember) {
-        Boolean hasLikeByMe = checkLikeStatus(comment.getId(), currentMember.getId());
+        boolean hasLikeByMe = checkLikeStatus(comment.getId(), currentMember.getId());
         return CommentMyResponseDto.toDto(comment, hasLikeByMe);
     }
 

--- a/src/main/java/page/clab/api/domain/comment/dto/response/CommentMyResponseDto.java
+++ b/src/main/java/page/clab/api/domain/comment/dto/response/CommentMyResponseDto.java
@@ -30,6 +30,9 @@ public class CommentMyResponseDto {
     private LocalDateTime createdAt;
 
     public static CommentMyResponseDto toDto(Comment comment, boolean hasLikeByMe) {
+        if (comment.getBoard() == null) {
+            return null;
+        }
         return CommentMyResponseDto.builder()
                 .id(comment.getId())
                 .boardId(comment.getBoard().getId())

--- a/src/main/java/page/clab/api/domain/comment/dto/response/CommentMyResponseDto.java
+++ b/src/main/java/page/clab/api/domain/comment/dto/response/CommentMyResponseDto.java
@@ -30,7 +30,7 @@ public class CommentMyResponseDto {
     private LocalDateTime createdAt;
 
     public static CommentMyResponseDto toDto(Comment comment, boolean hasLikeByMe) {
-        if (comment.getBoard() == null) {
+        if (comment.getBoard() == null || comment.getIsDeleted()) {
             return null;
         }
         return CommentMyResponseDto.builder()


### PR DESCRIPTION
## Summary

> #332 

게시글을 삭제하고 내 댓글을 조회했을 때 NullPointerException이 발생
내 댓글 조회시 삭제된 댓글이 포함되는 문제

## Tasks

- 나의 댓글 조회시 삭제된 게시글이 포함되어 NullPointerException이 발생하는 문제 수정
- 내 댓글 조회시 삭제된 댓글이 포함되는 문제 수정

## ETC

## Screenshot
