### PR TITLE
게시글 및 댓글 반환 정보 수정 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/board/api/BoardController.java
+++ b/src/main/java/page/clab/api/domain/board/api/BoardController.java
@@ -41,10 +41,10 @@ public class BoardController {
     @Operation(summary = "[U] 커뮤니티 게시글 생성", description = "ROLE_USER 이상의 권한이 필요함")
     @Secured({"ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER"})
     @PostMapping("")
-    public ApiResponse<Long> createBoard(
+    public ApiResponse<String> createBoard(
             @Valid @RequestBody BoardRequestDto requestDto
     ) throws PermissionDeniedException {
-        Long id = boardService.createBoard(requestDto);
+        String id = boardService.createBoard(requestDto);
         return ApiResponse.success(id);
     }
 
@@ -98,21 +98,21 @@ public class BoardController {
     @PatchMapping("/{boardId}")
     @Operation(summary = "[U] 커뮤니티 게시글 수정", description = "ROLE_USER 이상의 권한이 필요함")
     @Secured({"ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER"})
-    public ApiResponse<Long> updateBoard(
+    public ApiResponse<String> updateBoard(
             @PathVariable(name = "boardId") Long boardId,
             @Valid @RequestBody BoardUpdateRequestDto requestDto
     ) throws PermissionDeniedException {
-        Long id = boardService.updateBoard(boardId, requestDto);
+        String id = boardService.updateBoard(boardId, requestDto);
         return ApiResponse.success(id);
     }
 
     @DeleteMapping("/{boardId}")
     @Operation(summary = "[U] 커뮤니티 게시글 삭제", description = "ROLE_USER 이상의 권한이 필요함")
     @Secured({"ROLE_USER", "ROLE_ADMIN", "ROLE_SUPER"})
-    public ApiResponse<Long> deleteBoard(
+    public ApiResponse<String> deleteBoard(
             @PathVariable(name = "boardId") Long boardId
     ) throws PermissionDeniedException {
-        Long id = boardService.deleteBoard(boardId);
+        String id = boardService.deleteBoard(boardId);
         return ApiResponse.success(id);
     }
 

--- a/src/main/java/page/clab/api/domain/board/application/BoardService.java
+++ b/src/main/java/page/clab/api/domain/board/application/BoardService.java
@@ -50,7 +50,7 @@ public class BoardService {
     private final CommentRepository commentRepository;
 
     @Transactional
-    public Long createBoard(BoardRequestDto requestDto) throws PermissionDeniedException {
+    public String createBoard(BoardRequestDto requestDto) throws PermissionDeniedException {
         Member currentMember = memberService.getCurrentMember();
         List<UploadedFile> uploadedFiles = uploadedFileService.getUploadedFilesByUrls(requestDto.getFileUrlList());
         Board board = BoardRequestDto.toEntity(requestDto, currentMember, uploadedFiles);
@@ -59,7 +59,7 @@ public class BoardService {
         if (board.shouldNotifyForNewBoard()) {
             notificationService.sendNotificationToMember(currentMember, "[" + board.getTitle() + "] 새로운 공지사항이 등록되었습니다.");
         }
-        return boardRepository.save(board).getId();
+        return boardRepository.save(board).getCategory().getKey();
     }
 
     @Transactional(readOnly = true)
@@ -91,13 +91,13 @@ public class BoardService {
     }
 
     @Transactional
-    public Long updateBoard(Long boardId, BoardUpdateRequestDto requestDto) throws PermissionDeniedException {
+    public String updateBoard(Long boardId, BoardUpdateRequestDto requestDto) throws PermissionDeniedException {
         Member currentMember = memberService.getCurrentMember();
         Board board = getBoardByIdOrThrow(boardId);
         board.validateAccessPermission(currentMember);
         board.update(requestDto);
         validationService.checkValid(board);
-        return boardRepository.save(board).getId();
+        return boardRepository.save(board).getCategory().getKey();
     }
 
     @Transactional
@@ -123,12 +123,12 @@ public class BoardService {
         return new PagedResponseDto<>(boards.map(this::mapToBoardListResponseDto));
     }
 
-    public Long deleteBoard(Long boardId) throws PermissionDeniedException {
+    public String deleteBoard(Long boardId) throws PermissionDeniedException {
         Member currentMember = memberService.getCurrentMember();
         Board board = getBoardByIdOrThrow(boardId);
         board.validateAccessPermission(currentMember);
         boardRepository.delete(board);
-        return board.getId();
+        return board.getCategory().getKey();
     }
 
     @NotNull

--- a/src/main/java/page/clab/api/domain/comment/application/CommentService.java
+++ b/src/main/java/page/clab/api/domain/comment/application/CommentService.java
@@ -51,7 +51,7 @@ public class CommentService {
     public Long createComment(Long parentId, Long boardId, CommentRequestDto requestDto) {
         Comment comment = createAndStoreComment(parentId, boardId, requestDto);
         sendNotificationForNewComment(comment);
-        return comment.getId();
+        return boardId;
     }
 
     @Transactional(readOnly = true)
@@ -89,7 +89,8 @@ public class CommentService {
         comment.validateAccessPermission(currentMember);
         comment.update(requestDto);
         validationService.checkValid(comment);
-        return commentRepository.save(comment).getId();
+        commentRepository.save(comment);
+        return comment.getBoard().getId();
     }
 
     public Long deleteComment(Long commentId) throws PermissionDeniedException {
@@ -98,7 +99,7 @@ public class CommentService {
         comment.validateAccessPermission(currentMember);
         comment.updateIsDeleted();
         commentRepository.save(comment);
-        return comment.getId();
+        return comment.getBoard().getId();
     }
 
     @Transactional

--- a/src/main/java/page/clab/api/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/page/clab/api/domain/comment/dto/response/CommentResponseDto.java
@@ -47,6 +47,7 @@ public class CommentResponseDto {
                     .children(comment.getChildren().stream()
                             .map(child -> CommentResponseDto.toDto(child, currentMemberId))
                             .toList())
+                    .createdAt(comment.getCreatedAt())
                     .build();
         }
         return CommentResponseDto.builder()


### PR DESCRIPTION
## Summary

> #334 

클라이언트에서 게시글, 댓글과 관련한 요청을 보낸 후 정보를 재요청할 수 있도록 반환정보를 변경합니다.
댓글이 작성된 일자를 추가로 반환합니다.

## Tasks

-  게시글 생성, 수정, 삭제시 삭제된 게시글의 카테고리가 반환되도록 변경
- 댓글 생성, 수정, 삭제시 게시글의 id를 반환하도록 변경
- 댓글 응답 정보에 생성일자(createdAt) 추가

## ETC

## Screenshot
![image](https://github.com/KGU-C-Lab/clab-server/assets/85067003/bf16fbf2-0cd9-4c67-b569-4d8908dd79da)
![image](https://github.com/KGU-C-Lab/clab-server/assets/85067003/c54d105d-f843-4665-9967-088357b90b52)
![image](https://github.com/KGU-C-Lab/clab-server/assets/85067003/9d8e4001-b30a-4438-9f8d-c1c73b238bba)