### PR TITLE
favicon.ico 차단 문제 수정

### DIFF
--- a/src/main/java/page/clab/api/global/config/SecurityConstants.java
+++ b/src/main/java/page/clab/api/global/config/SecurityConstants.java
@@ -9,6 +9,7 @@ public class SecurityConstants {
             "/resources/files/**",
             "/configuration/ui",
             "/configuration/security",
+            "/favicon.ico",
             "/webjars/**",
             "/error",
             "/"


### PR DESCRIPTION
## Summary

> #336 

favicon.ico에 대한 접근이 차단되어 비정상적인 접근으로 간주됨.

## Tasks

- favicon.ico 접근 허용

## ETC

## Screenshot
