### PR TITLE
공지사항 게시글에 대한 응답 변경 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/board/dto/response/BoardCategoryResponseDto.java
+++ b/src/main/java/page/clab/api/domain/board/dto/response/BoardCategoryResponseDto.java
@@ -26,11 +26,12 @@ public class BoardCategoryResponseDto {
     private LocalDateTime createdAt;
 
     public static BoardCategoryResponseDto toDto(Board board) {
+        WriterInfo writerInfo = WriterInfo.fromBoard(board);
         return BoardCategoryResponseDto.builder()
                 .id(board.getId())
                 .category(board.getCategory().getKey())
-                .writerId(board.isWantAnonymous() ? null : board.getMember().getId())
-                .writerName(board.isWantAnonymous() ? board.getNickname() : board.getMember().getName())
+                .writerId(writerInfo.getId())
+                .writerName(writerInfo.getName())
                 .title(board.getTitle())
                 .imageUrl(board.getImageUrl())
                 .createdAt(board.getCreatedAt())

--- a/src/main/java/page/clab/api/domain/board/dto/response/BoardDetailsResponseDto.java
+++ b/src/main/java/page/clab/api/domain/board/dto/response/BoardDetailsResponseDto.java
@@ -41,12 +41,13 @@ public class BoardDetailsResponseDto {
     private LocalDateTime createdAt;
 
     public static BoardDetailsResponseDto toDto(Board board, boolean hasLikeByMe, boolean isOwner) {
+        WriterInfo writerInfo = WriterInfo.fromBoardDetails(board);
         return BoardDetailsResponseDto.builder()
                 .id(board.getId())
-                .writerId(board.isWantAnonymous() ? null : board.getMember().getId())
-                .writerName(board.isWantAnonymous() ? board.getNickname() : board.getMember().getName())
-                .writerRoleLevel(board.isWantAnonymous() ? null : board.getMember().getRole().toRoleLevel())
-                .writerImageUrl(board.isWantAnonymous() ? null : board.getMember().getImageUrl())
+                .writerId(writerInfo.getId())
+                .writerName(writerInfo.getName())
+                .writerRoleLevel(writerInfo.getRoleLevel())
+                .writerImageUrl(writerInfo.getImageUrl())
                 .title(board.getTitle())
                 .content(board.getContent())
                 .files(UploadedFileResponseDto.toDto(board.getUploadedFiles()))

--- a/src/main/java/page/clab/api/domain/board/dto/response/BoardListResponseDto.java
+++ b/src/main/java/page/clab/api/domain/board/dto/response/BoardListResponseDto.java
@@ -3,7 +3,6 @@ package page.clab.api.domain.board.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 import page.clab.api.domain.board.domain.Board;
-import page.clab.api.domain.board.domain.BoardCategory;
 
 import java.time.LocalDateTime;
 
@@ -30,10 +29,11 @@ public class BoardListResponseDto {
     private LocalDateTime createdAt;
 
     public static BoardListResponseDto toDto(Board board, Long commentCount) {
+        WriterInfo writerInfo = WriterInfo.fromBoard(board);
         return BoardListResponseDto.builder()
                 .id(board.getId())
-                .writerId(board.isWantAnonymous() ? null : board.getMember().getId())
-                .writerName(board.isWantAnonymous() ? board.getNickname() : board.getMember().getName())
+                .writerId(writerInfo.getId())
+                .writerName(writerInfo.getName())
                 .category(board.getCategory().getKey())
                 .title(board.getTitle())
                 .content(board.getContent())

--- a/src/main/java/page/clab/api/domain/board/dto/response/WriterInfo.java
+++ b/src/main/java/page/clab/api/domain/board/dto/response/WriterInfo.java
@@ -1,0 +1,48 @@
+package page.clab.api.domain.board.dto.response;
+
+import lombok.Getter;
+import page.clab.api.domain.board.domain.Board;
+import page.clab.api.domain.member.domain.Role;
+
+@Getter
+public class WriterInfo {
+
+    private String id;
+
+    private String name;
+
+    private Long roleLevel;
+
+    private String imageUrl;
+
+    public WriterInfo(String id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public WriterInfo(String id, String name, Long roleLevel, String imageUrl) {
+        this.id = id;
+        this.name = name;
+        this.roleLevel = roleLevel;
+        this.imageUrl = imageUrl;
+    }
+
+    public static WriterInfo fromBoard(Board board) {
+        if (board.getMember().isAdminRole() && board.isNotice()) {
+            return new WriterInfo(null, "운영진");
+        } else if (board.isWantAnonymous()) {
+            return new WriterInfo(null, board.getNickname());
+        }
+        return new WriterInfo(board.getMember().getId(), board.getMember().getName());
+    }
+
+    public static WriterInfo fromBoardDetails(Board board) {
+        if (board.getMember().isAdminRole() && board.isNotice()) {
+            return new WriterInfo(null, "운영진", Role.ADMIN.toRoleLevel(), null);
+        } else if (board.isWantAnonymous()) {
+            return new WriterInfo(null, board.getNickname(), null, null);
+        }
+        return new WriterInfo(board.getMember().getId(), board.getMember().getName(), board.getMember().getRole().toRoleLevel(), board.getMember().getImageUrl());
+    }
+
+}


### PR DESCRIPTION
## Summary

> #338 

공지사항이 카테고리인 게시글의 경우, 운영진이 작성한 게시글임을 표시하기 위해 이름을 운영진으로 표기합니다.

## Tasks

- 게시글 조회에서 운영진이 작성한 공지사항 게시글일 경우 응답 정보를 변경
- 기존 익명 처리와 더해져 분기처리가 많아짐에 따라 작성자의 정보를 관리하는 클래스를 작성하여 로직을 분리

## ETC

## Screenshot
![image](https://github.com/KGU-C-Lab/clab-server/assets/85067003/013a1a6d-8044-4db6-9bb6-f97a309d7694)
![image](https://github.com/KGU-C-Lab/clab-server/assets/85067003/fece1f8a-f13b-45c3-ba5e-11c9e15f9811)
