### PR TITLE
OTP 활성 정보가 없어 발생하는 로그인 문제 해결

### DIFF
--- a/src/main/java/page/clab/api/domain/application/domain/Application.java
+++ b/src/main/java/page/clab/api/domain/application/domain/Application.java
@@ -105,7 +105,9 @@ public class Application extends BaseEntity {
                 .interests(application.getInterests())
                 .githubUrl(application.getGithubUrl())
                 .studentStatus(StudentStatus.CURRENT)
+                .imageUrl("")
                 .role(Role.USER)
+                .isOtpEnabled(false)
                 .build();
     }
 

--- a/src/main/java/page/clab/api/domain/login/application/LoginService.java
+++ b/src/main/java/page/clab/api/domain/login/application/LoginService.java
@@ -29,6 +29,7 @@ import page.clab.api.global.common.slack.application.SlackService;
 import page.clab.api.global.util.HttpReqResUtil;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -125,7 +126,8 @@ public class LoginService {
     private LoginResult generateLoginResult(Member loginMember) {
         String memberId = loginMember.getId();
         String header;
-        if (loginMember.getIsOtpEnabled() || loginMember.isAdminRole()) {
+        boolean isOtpEnabled = Optional.ofNullable(loginMember.getIsOtpEnabled()).orElse(false);
+        if (isOtpEnabled || loginMember.isAdminRole()) {
             if (!authenticatorService.isAuthenticatorExist(memberId)) {
                 String secretKey = authenticatorService.generateSecretKey(memberId);
                 header = LoginHeader.create(secretKey).toJson();


### PR DESCRIPTION
## Summary

> #344 

로그인 시스템 개편 이후, 일부 API를 통해 새 멤버를 생성했을 때 OTP 정보가 null로 기입되어 로그인이 되지 않는 현상이 발생하고 있습니다.

## Tasks

- 동아리 지원 이후 합격자에 대한 멤버 생성 API 호출시 OTP 정보를 기입하도록 변경
- OTP 활성 정보가 없는 경우(null인 경우) OTP가 비활성화된 것으로 간주

## ETC

## Screenshot
