### PR TITLE
슬랙 메시지 개선 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/login/domain/RedisToken.java
+++ b/src/main/java/page/clab/api/domain/login/domain/RedisToken.java
@@ -49,4 +49,8 @@ public class RedisToken {
         return this.ip.equals(ip);
     }
 
+    public boolean isAdminToken() {
+        return role == Role.ADMIN || role == Role.SUPER;
+    }
+
 }

--- a/src/main/java/page/clab/api/global/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/page/clab/api/global/auth/filter/JwtAuthenticationFilter.java
@@ -77,7 +77,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
             }
             if (!redisToken.getIp().equals(clientIpAddress)) {
                 redisTokenService.deleteRedisTokenByAccessToken(token);
-                slackService.sendSecurityAlertNotification(request, SecurityAlertType.DUPLICATE_LOGIN, "토큰 발급 IP와 다른 IP에서 접속하여 토큰을 삭제하였습니다.");
+                sendSlackMessage(request, redisToken);
                 log.warn("[{}] 토큰 발급 IP와 다른 IP에서 접속하여 토큰을 삭제하였습니다.", clientIpAddress);
                 ResponseUtil.sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED);
                 return false;
@@ -87,6 +87,13 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
             return true;
         } else {
             return true;
+        }
+    }
+
+    private void sendSlackMessage(HttpServletRequest request, RedisToken redisToken) {
+        if (redisToken.isAdminToken()) {
+            request.setAttribute("memberId", redisToken.getId());
+            slackService.sendSecurityAlertNotification(request, SecurityAlertType.DUPLICATE_LOGIN, "토큰 발급 IP와 다른 IP에서 접속하여 토큰을 삭제하였습니다.");
         }
     }
 

--- a/src/main/java/page/clab/api/global/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/page/clab/api/global/auth/filter/JwtAuthenticationFilter.java
@@ -92,7 +92,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
 
     private void sendSlackMessage(HttpServletRequest request, RedisToken redisToken) {
         if (redisToken.isAdminToken()) {
-            request.setAttribute("memberId", redisToken.getId());
+            request.setAttribute("member", redisToken.getId());
             slackService.sendSecurityAlertNotification(request, SecurityAlertType.DUPLICATE_LOGIN, "토큰 발급 IP와 다른 IP에서 접속하여 토큰을 삭제하였습니다.");
         }
     }

--- a/src/main/java/page/clab/api/global/common/slack/application/SlackService.java
+++ b/src/main/java/page/clab/api/global/common/slack/application/SlackService.java
@@ -255,7 +255,7 @@ public class SlackService {
 
     private @NotNull String getUsername(HttpServletRequest request) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        return Optional.ofNullable(request.getAttribute("memberId"))
+        return Optional.ofNullable(request.getAttribute("member"))
                 .map(Object::toString)
                 .orElseGet(() -> Optional.ofNullable(authentication)
                         .map(Authentication::getName)


### PR DESCRIPTION
## Summary

> #346 

일부 슬랙 메시지에 대한 개선을 목표로 합니다.
개선 대상은 다음과 같습니다.

- 로그인에 대한 보안 경고
- 템플릿

## Tasks

- 중복 로그인 및 지속적인 로그인 실패에 대한 경고 대상을 관리자 이상의 멤버로 제한
- 중복 로그인 및 지속적인 로그인 실패에 대한 사용자의 정보를 메시지에 표기할 수 있도록 개선
- 미리보기에서 제목 확인이 가능하도록 개선

## ETC

## Screenshot
<img width="405" alt="image" src="https://github.com/KGU-C-Lab/clab-server/assets/85067003/772f9e88-d607-49bb-a338-bc9c29dbc698">