### PR TITLE
클라이언트 입력값에 대한 처리 개선 완료

### DIFF
--- a/src/main/java/page/clab/api/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/page/clab/api/global/handler/GlobalExceptionHandler.java
@@ -87,6 +87,7 @@ public class GlobalExceptionHandler {
             HttpMessageNotReadableException.class,
             MethodArgumentTypeMismatchException.class,
             IllegalAccessException.class,
+            NumberFormatException.class,
     })
     public ErrorResponse badRequestException(HttpServletResponse response, Exception e) {
         response.setStatus(HttpServletResponse.SC_OK);


### PR DESCRIPTION
## Summary

> #349 

OTP 인증번호에 숫자 이외의 문자열이 포함된 경우 NumberFormatException과 함께 상태코드 500이 반환되고 있습니다.
현재 백엔드 시스템에서 OTP를 제외하더라도 항상 올바른 타입에 대해서만 로직이 실행되도록 하고 있기에 NumberFormatException가 발생한 경우 400 Bad Request로 처리하도록 변경합니다.

## Tasks

- 예외 핸들러에서 NumberFormatException에 대해 400 Bad Request로 응답하도록 변경

## ETC

## Screenshot
변경 전
![image](https://github.com/KGU-C-Lab/clab-server/assets/85067003/b24269af-60fe-41e2-8d68-29d551542897)

변경 후
![image](https://github.com/KGU-C-Lab/clab-server/assets/85067003/4352c999-d77f-4679-a2e0-43da4f3f1a05)