### PR TITLE
커뮤니티 게시글 조회 API 개선 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/board/application/BoardService.java
+++ b/src/main/java/page/clab/api/domain/board/application/BoardService.java
@@ -87,7 +87,7 @@ public class BoardService {
     @Transactional(readOnly = true)
     public PagedResponseDto<BoardCategoryResponseDto> getBoardsByCategory(BoardCategory category, Pageable pageable) {
         Page<Board> boards = getBoardByCategory(category, pageable);
-        return new PagedResponseDto<>(boards.map(BoardCategoryResponseDto::toDto));
+        return new PagedResponseDto<>(boards.map(this::mapToBoardCategoryResponseDto));
     }
 
     @Transactional
@@ -135,6 +135,12 @@ public class BoardService {
     private BoardListResponseDto mapToBoardListResponseDto(Board board) {
         Long commentCount = commentRepository.countByBoard(board);
         return BoardListResponseDto.toDto(board, commentCount);
+    }
+
+    @NotNull
+    private BoardCategoryResponseDto mapToBoardCategoryResponseDto(Board board) {
+        Long commentCount = commentRepository.countByBoard(board);
+        return BoardCategoryResponseDto.toDto(board, commentCount);
     }
 
     public Board getBoardByIdOrThrow(Long boardId) {

--- a/src/main/java/page/clab/api/domain/board/dto/response/BoardCategoryResponseDto.java
+++ b/src/main/java/page/clab/api/domain/board/dto/response/BoardCategoryResponseDto.java
@@ -21,11 +21,13 @@ public class BoardCategoryResponseDto {
 
     private String title;
 
+    private Long commentCount;
+
     private String imageUrl;
 
     private LocalDateTime createdAt;
 
-    public static BoardCategoryResponseDto toDto(Board board) {
+    public static BoardCategoryResponseDto toDto(Board board, Long commentCount) {
         WriterInfo writerInfo = WriterInfo.fromBoard(board);
         return BoardCategoryResponseDto.builder()
                 .id(board.getId())
@@ -33,6 +35,7 @@ public class BoardCategoryResponseDto {
                 .writerId(writerInfo.getId())
                 .writerName(writerInfo.getName())
                 .title(board.getTitle())
+                .commentCount(commentCount)
                 .imageUrl(board.getImageUrl())
                 .createdAt(board.getCreatedAt())
                 .build();


### PR DESCRIPTION
## Summary

> #356 

ETC에 첨부된 사진과 같이 현재 게시글에 대한 간략한 정보만 응답으로 보내 표시하도록 설계되어있습니다.
글에 들어가지 않더라도, 목록에서 게시글에 작성된 댓글의 개수를 확인할 수 있도록 개선합니다.

## Tasks

- 응답에 댓글 개수 정보 추가

## ETC

## Screenshot
![image](https://github.com/KGU-C-Lab/clab-server/assets/85067003/ef5b745f-359e-4bc2-b45b-87a0c14321ee)
