### PR TITLE
대댓글의 순서가 정렬되지 않는 버그 해결

### DIFF
--- a/src/main/java/page/clab/api/domain/comment/application/CommentService.java
+++ b/src/main/java/page/clab/api/domain/comment/application/CommentService.java
@@ -67,10 +67,6 @@ public class CommentService {
         return new PagedResponseDto<>(commentDtos);
     }
 
-    private void sortChildrenComments(Comment comment) {
-        comment.getChildren().sort(Comparator.comparing(Comment::getCreatedAt));
-    }
-
     @Transactional(readOnly = true)
     public PagedResponseDto<CommentMyResponseDto> getMyComments(Pageable pageable) {
         Member currentMember = memberService.getCurrentMember();
@@ -184,6 +180,10 @@ public class CommentService {
     private CommentMyResponseDto toCommentMyResponseDto(Comment comment, Member currentMember) {
         boolean hasLikeByMe = checkLikeStatus(comment.getId(), currentMember.getId());
         return CommentMyResponseDto.toDto(comment, hasLikeByMe);
+    }
+
+    private void sortChildrenComments(Comment comment) {
+        comment.getChildren().sort(Comparator.comparing(Comment::getCreatedAt));
     }
 
 }

--- a/src/main/java/page/clab/api/domain/comment/domain/Comment.java
+++ b/src/main/java/page/clab/api/domain/comment/domain/Comment.java
@@ -57,12 +57,12 @@ public class Comment extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "parent_id")
     @JsonIgnoreProperties("children")
-    @OrderBy("createdAt ASC")
     private Comment parent;
 
     @Builder.Default
     @OneToMany(mappedBy = "parent", orphanRemoval = true)
     @JsonIgnoreProperties("parent")
+    @OrderBy("createdAt ASC")
     private List<Comment> children = new ArrayList<>();
 
     @Column(nullable = false)

--- a/src/main/java/page/clab/api/domain/comment/domain/Comment.java
+++ b/src/main/java/page/clab/api/domain/comment/domain/Comment.java
@@ -62,7 +62,6 @@ public class Comment extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "parent", orphanRemoval = true)
     @JsonIgnoreProperties("parent")
-    @OrderBy("createdAt ASC")
     private List<Comment> children = new ArrayList<>();
 
     @Column(nullable = false)

--- a/src/main/java/page/clab/api/domain/comment/domain/Comment.java
+++ b/src/main/java/page/clab/api/domain/comment/domain/Comment.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -56,6 +57,7 @@ public class Comment extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "parent_id")
     @JsonIgnoreProperties("children")
+    @OrderBy("createdAt ASC")
     private Comment parent;
 
     @Builder.Default


### PR DESCRIPTION
## Summary

> #359 

대댓글의 순서가 오래된 순으로 정렬되어 보이도록 수정했습니다.

## Tasks

대댓글 정렬 순서 어노테이션으로 명시

## Screenshot

![image](https://github.com/KGU-C-Lab/clab-server/assets/96719969/b0347647-1b47-4314-bd19-bba9af98aa13)

![image](https://github.com/KGU-C-Lab/clab-server/assets/96719969/a47acf54-9a3e-449f-b6a3-976e0e9952a7)

