### PR TITLE
IP 지리적 위치 서비스 개선 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/login/application/LoginAttemptLogService.java
+++ b/src/main/java/page/clab/api/domain/login/application/LoginAttemptLogService.java
@@ -24,7 +24,7 @@ public class LoginAttemptLogService {
     @Transactional
     public void createLoginAttemptLog(HttpServletRequest request, String memberId, LoginAttemptResult loginAttemptResult) {
         String clientIpAddress = HttpReqResUtil.getClientIpAddressIfServletRequestExist();
-        IPResponse ipResponse = HttpReqResUtil.isLocalRequest(clientIpAddress) ? null : IPInfoUtil.getIpInfo(request);
+        IPResponse ipResponse = HttpReqResUtil.isBogonRequest(clientIpAddress) ? null : IPInfoUtil.getIpInfo(request);
         LoginAttemptLog loginAttemptLog = LoginAttemptLog.create(memberId, request, clientIpAddress, ipResponse, loginAttemptResult);
         loginAttemptLogRepository.save(loginAttemptLog);
     }

--- a/src/main/java/page/clab/api/global/auth/filter/IpAuthenticationFilter.java
+++ b/src/main/java/page/clab/api/global/auth/filter/IpAuthenticationFilter.java
@@ -60,7 +60,7 @@ public class IpAuthenticationFilter implements Filter {
     private boolean shouldProcessRequest(HttpServletRequest httpRequest, String clientIpAddress) {
         return !interceptorStrategy.shouldRun(httpRequest)
                 || attributeStrategy.hasAttribute(httpRequest)
-                || HttpReqResUtil.isLocalRequest(clientIpAddress)
+                || HttpReqResUtil.isBogonRequest(clientIpAddress)
                 || clientIpAddress.equals("0.0.0.0");
     }
 

--- a/src/main/java/page/clab/api/global/auth/filter/IpAuthenticationFilter.java
+++ b/src/main/java/page/clab/api/global/auth/filter/IpAuthenticationFilter.java
@@ -1,23 +1,20 @@
 package page.clab.api.global.auth.filter;
 
 import io.ipinfo.api.IPinfo;
-import io.ipinfo.api.errors.RateLimitedException;
 import io.ipinfo.api.model.IPResponse;
-import io.ipinfo.spring.strategies.attribute.AttributeStrategy;
-import io.ipinfo.spring.strategies.interceptor.InterceptorStrategy;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import page.clab.api.global.config.IPInfoConfig;
 import page.clab.api.global.util.HttpReqResUtil;
 
 import java.io.IOException;
+import java.util.Objects;
 
 @Component
 @Slf4j
@@ -25,58 +22,33 @@ public class IpAuthenticationFilter implements Filter {
 
     private final IPinfo ipInfo;
 
-    private final AttributeStrategy attributeStrategy;
-
-    private final InterceptorStrategy interceptorStrategy;
-
     public IpAuthenticationFilter(IPInfoConfig ipInfoConfig) {
         ipInfo = ipInfoConfig.ipInfo();
-        attributeStrategy = ipInfoConfig.attributeStrategy();
-        interceptorStrategy = ipInfoConfig.interceptorStrategy();
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+        log.info("IP Authentication Filter initialized.");
     }
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        HttpServletRequest httpRequest = (HttpServletRequest) request;
         String clientIpAddress = HttpReqResUtil.getClientIpAddressIfServletRequestExist();
         try {
-            if (shouldProcessRequest(httpRequest, clientIpAddress)) {
-                chain.doFilter(request, response);
-                return;
-            }
-            IPResponse ipResponse = storeIpInformation(clientIpAddress, httpRequest);
+            IPResponse ipResponse = ipInfo.lookupIP(clientIpAddress);
             if (isNonPermittedCountry(ipResponse)) {
                 log.warn("[{}:{}] Access from non-permitted country", clientIpAddress, ipResponse.getCountryName());
                 return;
             }
-        } catch (RateLimitedException e) {
-            log.error("Rate limit exceeded while getting IP information.");
         } catch (Exception e) {
             log.error("Failed to get IP information.");
         }
         chain.doFilter(request, response);
     }
 
-    private boolean shouldProcessRequest(HttpServletRequest httpRequest, String clientIpAddress) {
-        return !interceptorStrategy.shouldRun(httpRequest)
-                || attributeStrategy.hasAttribute(httpRequest)
-                || HttpReqResUtil.isBogonRequest(clientIpAddress);
-    }
-
-    private IPResponse storeIpInformation(String clientIpAddress, HttpServletRequest httpRequest) throws RateLimitedException {
-        IPResponse ipResponse = ipInfo.lookupIP(clientIpAddress);
-        attributeStrategy.storeAttribute(httpRequest, ipResponse);
-        return ipResponse;
-    }
-
     private boolean isNonPermittedCountry(IPResponse ipResponse) {
         String country = ipResponse.getCountryCode();
-        return country != null && !country.equals("KR");
-    }
-
-    @Override
-    public void init(FilterConfig filterConfig) {
-        log.info("IP Authentication Filter initialized.");
+        return Objects.nonNull(country) && !country.equals("KR");
     }
 
     @Override

--- a/src/main/java/page/clab/api/global/auth/filter/IpAuthenticationFilter.java
+++ b/src/main/java/page/clab/api/global/auth/filter/IpAuthenticationFilter.java
@@ -60,8 +60,7 @@ public class IpAuthenticationFilter implements Filter {
     private boolean shouldProcessRequest(HttpServletRequest httpRequest, String clientIpAddress) {
         return !interceptorStrategy.shouldRun(httpRequest)
                 || attributeStrategy.hasAttribute(httpRequest)
-                || HttpReqResUtil.isBogonRequest(clientIpAddress)
-                || clientIpAddress.equals("0.0.0.0");
+                || HttpReqResUtil.isBogonRequest(clientIpAddress);
     }
 
     private IPResponse storeIpInformation(String clientIpAddress, HttpServletRequest httpRequest) throws RateLimitedException {

--- a/src/main/java/page/clab/api/global/config/SecurityConfig.java
+++ b/src/main/java/page/clab/api/global/config/SecurityConfig.java
@@ -30,6 +30,7 @@ import page.clab.api.global.auth.filter.IpAuthenticationFilter;
 import page.clab.api.global.auth.filter.JwtAuthenticationFilter;
 import page.clab.api.global.auth.jwt.JwtTokenProvider;
 import page.clab.api.global.common.slack.application.SlackService;
+import page.clab.api.global.filter.IPinfoSpringFilter;
 import page.clab.api.global.util.HttpReqResUtil;
 import page.clab.api.global.util.ResponseUtil;
 
@@ -80,6 +81,10 @@ public class SecurityConfig {
                 )
                 .authorizeRequests(this::configureRequests)
                 .authenticationProvider(authenticationConfig.authenticationProvider())
+                .addFilterBefore(
+                        new IPinfoSpringFilter(ipInfoConfig),
+                        UsernamePasswordAuthenticationFilter.class
+                )
                 .addFilterBefore(
                         new IpAuthenticationFilter(ipInfoConfig),
                         UsernamePasswordAuthenticationFilter.class

--- a/src/main/java/page/clab/api/global/filter/IPinfoSpringFilter.java
+++ b/src/main/java/page/clab/api/global/filter/IPinfoSpringFilter.java
@@ -1,0 +1,75 @@
+package page.clab.api.global.filter;
+
+import io.ipinfo.api.IPinfo;
+import io.ipinfo.api.model.IPResponse;
+import io.ipinfo.spring.strategies.attribute.AttributeStrategy;
+import io.ipinfo.spring.strategies.interceptor.InterceptorStrategy;
+import io.ipinfo.spring.strategies.ip.IPStrategy;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import page.clab.api.global.config.IPInfoConfig;
+
+import java.io.IOException;
+import java.util.Objects;
+
+@Slf4j
+public class IPinfoSpringFilter implements Filter {
+
+    private final IPinfo ii;
+
+    private final AttributeStrategy attributeStrategy;
+
+    private final IPStrategy ipStrategy;
+
+    private final InterceptorStrategy interceptorStrategy;
+
+    public IPinfoSpringFilter(IPInfoConfig ipInfoConfig) {
+        this.ii = ipInfoConfig.ipInfo();
+        this.attributeStrategy = ipInfoConfig.attributeStrategy();
+        this.ipStrategy = ipInfoConfig.ipStrategy();
+        this.interceptorStrategy = ipInfoConfig.interceptorStrategy();
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+        log.info("Initializing IPinfoSpringFilter");
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        String clientIpAddress = ipStrategy.getIPAddress(httpRequest);
+
+        if (shouldProcessRequest(httpRequest, clientIpAddress)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            IPResponse ipResponse = ii.lookupIP(clientIpAddress);
+            attributeStrategy.storeAttribute(httpRequest, ipResponse);
+        } catch (Exception e) {
+            log.error("Error while fetching IP information: {}", e.getMessage());
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private boolean shouldProcessRequest(HttpServletRequest httpRequest, String clientIpAddress) {
+        return !interceptorStrategy.shouldRun(httpRequest)
+                || attributeStrategy.hasAttribute(httpRequest)
+                || Objects.isNull(clientIpAddress);
+    }
+
+    @Override
+    public void destroy() {
+        log.info("Destroying IPinfoSpringFilter");
+    }
+
+}

--- a/src/main/java/page/clab/api/global/util/HttpReqResUtil.java
+++ b/src/main/java/page/clab/api/global/util/HttpReqResUtil.java
@@ -1,14 +1,74 @@
 package page.clab.api.global.util;
 
+import io.ipinfo.api.request.IPRequest;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-import java.util.Set;
+import java.util.Arrays;
 
 public class HttpReqResUtil {
 
-    private static final Set<String> localIpSet = Set.of("0:0:0:0:0:0:0:1", "127.0.0.1", "192.168.0.1");
+    private static final IPRequest.IpAddressMatcher[] IpAddressMatcherList = {
+            // IPv4
+            new IPRequest.IpAddressMatcher("0.0.0.0/8"),
+            new IPRequest.IpAddressMatcher("10.0.0.0/8"),
+            new IPRequest.IpAddressMatcher("100.64.0.0/10"),
+            new IPRequest.IpAddressMatcher("127.0.0.0/8"),
+            new IPRequest.IpAddressMatcher("169.254.0.0/16"),
+            new IPRequest.IpAddressMatcher("172.16.0.0/12"),
+            new IPRequest.IpAddressMatcher("192.0.0.0/24"),
+            new IPRequest.IpAddressMatcher("192.0.2.0/24"),
+            new IPRequest.IpAddressMatcher("192.168.0.0/16"),
+            new IPRequest.IpAddressMatcher("198.18.0.0/15"),
+            new IPRequest.IpAddressMatcher("198.51.100.0/24"),
+            new IPRequest.IpAddressMatcher("203.0.113.0/24"),
+            new IPRequest.IpAddressMatcher("224.0.0.0/4"),
+            new IPRequest.IpAddressMatcher("240.0.0.0/4"),
+            new IPRequest.IpAddressMatcher("255.255.255.255/32"),
+            // IPv6
+            new IPRequest.IpAddressMatcher("::/128"),
+            new IPRequest.IpAddressMatcher("::1/128"),
+            new IPRequest.IpAddressMatcher("::ffff:0:0/96"),
+            new IPRequest.IpAddressMatcher("::/96"),
+            new IPRequest.IpAddressMatcher("100::/64"),
+            new IPRequest.IpAddressMatcher("2001:10::/28"),
+            new IPRequest.IpAddressMatcher("2001:db8::/32"),
+            new IPRequest.IpAddressMatcher("fc00::/7"),
+            new IPRequest.IpAddressMatcher("fe80::/10"),
+            new IPRequest.IpAddressMatcher("fec0::/10"),
+            new IPRequest.IpAddressMatcher("ff00::/8"),
+            // 6to4
+            new IPRequest.IpAddressMatcher("2002::/24"),
+            new IPRequest.IpAddressMatcher("2002:a00::/24"),
+            new IPRequest.IpAddressMatcher("2002:7f00::/24"),
+            new IPRequest.IpAddressMatcher("2002:a9fe::/32"),
+            new IPRequest.IpAddressMatcher("2002:ac10::/28"),
+            new IPRequest.IpAddressMatcher("2002:c000::/40"),
+            new IPRequest.IpAddressMatcher("2002:c000:200::/40"),
+            new IPRequest.IpAddressMatcher("2002:c0a8::/32"),
+            new IPRequest.IpAddressMatcher("2002:c612::/31"),
+            new IPRequest.IpAddressMatcher("2002:c633:6400::/40"),
+            new IPRequest.IpAddressMatcher("2002:cb00:7100::/40"),
+            new IPRequest.IpAddressMatcher("2002:e000::/20"),
+            new IPRequest.IpAddressMatcher("2002:f000::/20"),
+            new IPRequest.IpAddressMatcher("2002:ffff:ffff::/48"),
+            // Teredo
+            new IPRequest.IpAddressMatcher("2001::/40"),
+            new IPRequest.IpAddressMatcher("2001:0:a00::/40"),
+            new IPRequest.IpAddressMatcher("2001:0:7f00::/40"),
+            new IPRequest.IpAddressMatcher("2001:0:a9fe::/48"),
+            new IPRequest.IpAddressMatcher("2001:0:ac10::/44"),
+            new IPRequest.IpAddressMatcher("2001:0:c000::/56"),
+            new IPRequest.IpAddressMatcher("2001:0:c000:200::/56"),
+            new IPRequest.IpAddressMatcher("2001:0:c0a8::/48"),
+            new IPRequest.IpAddressMatcher("2001:0:c612::/47"),
+            new IPRequest.IpAddressMatcher("2001:0:c633:6400::/56"),
+            new IPRequest.IpAddressMatcher("2001:0:cb00:7100::/56"),
+            new IPRequest.IpAddressMatcher("2001:0:e000::/36"),
+            new IPRequest.IpAddressMatcher("2001:0:f000::/36"),
+            new IPRequest.IpAddressMatcher("2001:0:ffff:ffff::/64")
+    };
 
     private static final String[] IP_HEADER_CANDIDATES = {
             "X-Forwarded-For",
@@ -38,8 +98,9 @@ public class HttpReqResUtil {
         return request.getRemoteAddr();
     }
 
-    public static boolean isLocalRequest(String ipAddress) {
-        return localIpSet.contains(ipAddress);
+    public static boolean isBogonRequest(String ip) {
+        return Arrays.stream(IpAddressMatcherList)
+                .anyMatch(ipAddressMatcher -> ipAddressMatcher.matches(ip));
     }
 
 }


### PR DESCRIPTION
## Summary

> #326 

[1]
기존 일부 IP를 대상으로 정적으로 처리하던 사설 IP(Bogon IP) 판별 로직을 강화합니다.

[2]
IP 정보를 가져오는 서비스와 해외 IP를 차단하는 서비스가 강결합되어있다고 판단됩니다.
변경 용이성 및 단일 책임 원칙을 고려하여 각 서비스를 분리하여 필터로 구성합니다.

## Tasks

- Bogon IP 판별 로직 개선
- 요청 IP에 대한 정보 수집/차단 필터 분리

## ETC
스크린샷의 로그는 테스트 목적으로 임시로 작성한 로그이며, 커밋에 포함되지 않습니다.

## Screenshot
`IPinfoSpringFilter`에서 IP 정보를 수집하고 `IpAuthenticationFilter`에서 해외 IP를 차단하는 과정이 순차적, 정상적으로 이루어짐을 확인할 수 있습니다.
![image](https://github.com/KGU-C-Lab/clab-server/assets/85067003/023f725d-4d9c-4c43-b17f-61db59ce5401)