### PR TITLE
이미지 파일 업로드 시 회전 버그 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,11 @@ dependencies {
     implementation 'com.navercorp.lucy:lucy-xss:1.6.3' // Lucy XSS Filter
     implementation 'org.apache.commons:commons-text:1.11.0' // Apache Commons Text
 
+    // Image
+    implementation 'commons-io:commons-io:2.8.0'
+    implementation 'com.drewnoakes:metadata-extractor:2.14.0'
+    implementation 'org.imgscalr:imgscalr-lib:4.2'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test' // Spring Boot Test
     testImplementation 'org.springframework.security:spring-security-test' // Spring Security Test

--- a/src/main/java/page/clab/api/global/common/file/application/FileHandler.java
+++ b/src/main/java/page/clab/api/global/common/file/application/FileHandler.java
@@ -1,8 +1,10 @@
 package page.clab.api.global.common.file.application;
 
 import com.drew.imaging.ImageMetadataReader;
+import com.drew.imaging.ImageProcessingException;
 import com.drew.metadata.Directory;
 import com.drew.metadata.Metadata;
+import com.drew.metadata.MetadataException;
 import com.drew.metadata.exif.ExifIFD0Directory;
 import com.google.common.base.Strings;
 import java.io.FileOutputStream;
@@ -122,8 +124,14 @@ public class FileHandler {
             if (directory != null) {
                 originalDirection = directory.getInt(ExifIFD0Directory.TAG_ORIENTATION);
             }
+        } catch (IOException e) {
+            log.error("이미지 파일을 읽는 중 IO 오류 발생: " + e.getMessage());
+        } catch (ImageProcessingException e) {
+            log.error("이미지 파일 처리 중 오류 발생: " + e.getMessage());
+        } catch (MetadataException e) {
+            log.error("이미지 파일의 메타데이터를 읽는 중 오류 발생: " + e.getMessage());
         } catch (Exception e) {
-            originalDirection = 1;
+            log.error("예기치 않은 오류 발생: " + e.getMessage());
         }
         return originalDirection;
     }

--- a/src/main/java/page/clab/api/global/common/file/application/FileHandler.java
+++ b/src/main/java/page/clab/api/global/common/file/application/FileHandler.java
@@ -79,8 +79,13 @@ public class FileHandler {
         ensureParentDirectoryExists(file);
 
         try {
-            BufferedImage originalImage = adjustImageDirection(multipartFile);
-            ImageIO.write(originalImage, extension, file);
+            if (isImageFile(multipartFile)) {
+                BufferedImage originalImage = adjustImageDirection(multipartFile);
+                ImageIO.write(originalImage, extension, file);
+            }
+            else {
+                multipartFile.transferTo(file);
+            }
         } catch (Exception e) {
             throw new IOException("이미지의 뱡향을 조정하는데 오류가 발생했습니다.", e);
         }
@@ -134,6 +139,11 @@ public class FileHandler {
             log.error("예기치 않은 오류 발생: " + e.getMessage());
         }
         return originalDirection;
+    }
+
+    private boolean isImageFile(MultipartFile file) {
+        String contentType = file.getContentType();
+        return contentType != null && contentType.startsWith("image/");
     }
 
     private void validateFileAttributes(String originalFilename, String extension) throws FileUploadFailException {

--- a/src/main/java/page/clab/api/global/common/file/application/FileHandler.java
+++ b/src/main/java/page/clab/api/global/common/file/application/FileHandler.java
@@ -130,13 +130,13 @@ public class FileHandler {
                 originalDirection = directory.getInt(ExifIFD0Directory.TAG_ORIENTATION);
             }
         } catch (IOException e) {
-            log.error("이미지 파일을 읽는 중 IO 오류 발생: " + e.getMessage());
+            log.error("이미지 파일을 읽는 중 IO 오류 발생: {}", e.getMessage());
         } catch (ImageProcessingException e) {
-            log.error("이미지 파일 처리 중 오류 발생: " + e.getMessage());
+            log.error("이미지 파일 처리 중 오류 발생: {}", e.getMessage());
         } catch (MetadataException e) {
-            log.error("이미지 파일의 메타데이터를 읽는 중 오류 발생: " + e.getMessage());
+            log.error("이미지 파일의 메타데이터를 읽는 중 오류 발생: {}", e.getMessage());
         } catch (Exception e) {
-            log.error("예기치 않은 오류 발생: " + e.getMessage());
+            log.error("예기치 않은 오류 발생: {}", e.getMessage());
         }
         return originalDirection;
     }

--- a/src/main/java/page/clab/api/global/config/WebConfig.java
+++ b/src/main/java/page/clab/api/global/config/WebConfig.java
@@ -41,7 +41,7 @@ public class WebConfig implements WebMvcConfigurer {
         log.info("Resource UploadedFile Mapped : {} -> {}", fileURL, filePath);
         registry
                 .addResourceHandler(fileURL + "/**")
-                .addResourceLocations("file:" + File.separator + filePath + "/")
+                .addResourceLocations("file://" + filePath + "/")
                 .resourceChain(true)
                 .addResolver(new PathResourceResolver() {
                     @Override

--- a/src/main/java/page/clab/api/global/config/WebConfig.java
+++ b/src/main/java/page/clab/api/global/config/WebConfig.java
@@ -1,6 +1,7 @@
 package page.clab.api.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,7 +41,7 @@ public class WebConfig implements WebMvcConfigurer {
         log.info("Resource UploadedFile Mapped : {} -> {}", fileURL, filePath);
         registry
                 .addResourceHandler(fileURL + "/**")
-                .addResourceLocations("file://" + filePath + "/")
+                .addResourceLocations("file:" + File.separator + filePath + "/")
                 .resourceChain(true)
                 .addResolver(new PathResourceResolver() {
                     @Override

--- a/src/main/java/page/clab/api/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/page/clab/api/global/handler/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package page.clab.api.global.handler;
 
+import com.drew.imaging.ImageProcessingException;
+import com.drew.metadata.MetadataException;
 import com.google.gson.stream.MalformedJsonException;
 import jakarta.mail.MessagingException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -192,6 +194,8 @@ public class GlobalExceptionHandler {
             EncryptionException.class,
             DecryptionException.class,
             InvalidDataAccessApiUsageException.class,
+            ImageProcessingException.class,
+            MetadataException.class,
             Exception.class
     })
     public ApiResponse serverException(HttpServletRequest request, HttpServletResponse response, Exception e) {


### PR DESCRIPTION
## Summary

> #358 

이미지 파일 업로드 시 촬영 각도에 따라 회전하는 버그를 해결했습니다.

## Tasks

- 필요한 의존성을 추가하고 전송된 multipartfile의 회전정보에 따라
적절하게 다시 회전 후 서버에 이미지를 저장합니다.

## ETC


## Screenshot

<img width="1276" alt="image" src="https://github.com/KGU-C-Lab/clab-server/assets/96719969/af39926b-d8b9-4fcf-a233-e288fb4d6fb7">
