### PR TITLE
이메일 전송 로직 개선 완료

### DIFF
--- a/src/main/java/page/clab/api/global/common/email/application/EmailAsyncService.java
+++ b/src/main/java/page/clab/api/global/common/email/application/EmailAsyncService.java
@@ -1,0 +1,98 @@
+package page.clab.api.global.common.email.application;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeUtility;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import page.clab.api.global.common.email.domain.EmailTask;
+import page.clab.api.global.common.email.domain.EmailTemplateType;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static page.clab.api.global.common.email.application.EmailService.emailQueue;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class EmailAsyncService {
+
+    private final JavaMailSender javaMailSender;
+
+    @Value("${spring.mail.username}")
+    private String sender;
+
+    private static final int MAX_BATCH_SIZE = 10;
+
+    @Async
+    public void sendEmailAsync(String to, String subject, String content, List<File> files, EmailTemplateType emailTemplateType) throws MessagingException {
+        log.debug("Sending email to: {}", to);
+        emailQueue.add(new EmailTask(to, subject, content, files, emailTemplateType));
+    }
+
+    @Async
+    public void processEmailQueue() {
+        try {
+            List<EmailTask> batch = new ArrayList<>();
+            EmailTask task;
+            while ((task = emailQueue.poll()) != null) {
+                batch.add(task);
+                if (batch.size() >= MAX_BATCH_SIZE) {
+                    sendBatchEmail(batch);
+                    batch.clear();
+                }
+            }
+            if (!batch.isEmpty()) {
+                sendBatchEmail(batch);
+            }
+        } catch (Exception e) {
+            log.debug("Error processing email queue: {}", e.getMessage(), e);
+        }
+    }
+
+    public void sendBatchEmail(List<EmailTask> emailTasks) throws MessagingException, IOException {
+        MimeMessage[] mimeMessages = new MimeMessage[emailTasks.size()];
+        for (int i = 0; i < emailTasks.size(); i++) {
+            EmailTask task = emailTasks.get(i);
+            MimeMessage message = javaMailSender.createMimeMessage();
+            MimeMessageHelper messageHelper = new MimeMessageHelper(message, true, "UTF-8");
+            messageHelper.setFrom(sender);
+            messageHelper.setTo(task.getTo());
+            messageHelper.setSubject(task.getSubject());
+            messageHelper.setText(task.getContent(), true);
+            setImageInTemplate(messageHelper, task.getTemplateType());
+            if (task.getFiles() != null) {
+                for (File file : task.getFiles()) {
+                    messageHelper.addAttachment(MimeUtility.encodeText(file.getName(), "UTF-8", "B"), file);
+                }
+            }
+            mimeMessages[i] = message;
+        }
+
+        try {
+            javaMailSender.send(mimeMessages);
+        } catch (Exception e) {
+            log.error("Error sending batch email: " + e.getMessage(), e);
+        }
+        log.debug("Batch email sent successfully.");
+    }
+
+    private void setImageInTemplate(MimeMessageHelper messageHelper, EmailTemplateType templateType) throws MessagingException {
+        switch(templateType) {
+            case NORMAL -> {
+                messageHelper.addInline("image-1", new ClassPathResource("images/image-1.png"));
+                break;
+            }
+        }
+    }
+
+}

--- a/src/main/java/page/clab/api/global/common/email/application/EmailService.java
+++ b/src/main/java/page/clab/api/global/common/email/application/EmailService.java
@@ -1,17 +1,10 @@
 package page.clab.api.global.common.email.application;
 
 import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
-import jakarta.mail.internet.MimeUtility;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FilenameUtils;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.thymeleaf.context.Context;
@@ -19,6 +12,7 @@ import org.thymeleaf.spring6.SpringTemplateEngine;
 import page.clab.api.domain.member.application.MemberService;
 import page.clab.api.domain.member.domain.Member;
 import page.clab.api.domain.member.dto.response.MemberResponseDto;
+import page.clab.api.global.common.email.domain.EmailTask;
 import page.clab.api.global.common.email.domain.EmailTemplateType;
 import page.clab.api.global.common.email.dto.request.EmailDto;
 import page.clab.api.global.common.email.exception.MessageSendingFailedException;
@@ -37,21 +31,16 @@ import java.util.concurrent.LinkedBlockingQueue;
 @Slf4j
 public class EmailService {
 
-    private final JavaMailSender javaMailSender;
-
     private final MemberService memberService;
 
     private final SpringTemplateEngine springTemplateEngine;
 
-    @Value("${spring.mail.username}")
-    private String sender;
+    private final EmailAsyncService emailAsyncService;
 
     @Value("${resource.file.path}")
     private String filePath;
 
-    private static final int MAX_BATCH_SIZE = 10;
-
-    private static final BlockingQueue<EmailTask> emailQueue = new LinkedBlockingQueue<>();
+    protected static final BlockingQueue<EmailTask> emailQueue = new LinkedBlockingQueue<>();
 
     public List<String> broadcastEmail(EmailDto emailDto, List<MultipartFile> multipartFiles) {
         List<File> convertedFiles = multipartFiles != null && !multipartFiles.isEmpty()
@@ -64,12 +53,13 @@ public class EmailService {
             try {
                 Member recipient = memberService.getMemberByEmail(address);
                 String emailContent = generateEmailContent(emailDto, recipient.getName());
-                sendEmailAsync(address, emailDto.getSubject(), emailContent, convertedFiles, emailDto.getEmailTemplateType());
+                emailAsyncService.sendEmailAsync(address, emailDto.getSubject(), emailContent, convertedFiles, emailDto.getEmailTemplateType());
                 successfulAddresses.add(address);
             } catch (MessagingException e) {
                 throw new MessageSendingFailedException(address + "에게 이메일을 보내는데 실패했습니다.");
             }
         });
+        emailAsyncService.processEmailQueue();
         return successfulAddresses;
     }
 
@@ -84,12 +74,13 @@ public class EmailService {
         memberList.parallelStream().forEach(member -> {
             try {
                 String emailContent = generateEmailContent(emailDto, member.getName());
-                sendEmailAsync(member.getEmail(), emailDto.getSubject(), emailContent, convertedFiles, emailDto.getEmailTemplateType());
+                emailAsyncService.sendEmailAsync(member.getEmail(), emailDto.getSubject(), emailContent, convertedFiles, emailDto.getEmailTemplateType());
                 successfulEmails.add(member.getEmail());
             } catch (MessagingException e) {
                 throw new MessageSendingFailedException(member.getEmail() + "에게 이메일을 보내는데 실패했습니다.");
             }
         });
+        emailAsyncService.processEmailQueue();
         return successfulEmails;
     }
 
@@ -109,10 +100,11 @@ public class EmailService {
         EmailDto emailDto = EmailDto.create(List.of(member.getEmail()), subject, content, EmailTemplateType.NORMAL);
         try {
             String emailContent = generateEmailContent(emailDto, member.getName());
-            sendEmailAsync(member.getEmail(), emailDto.getSubject(), emailContent, null, emailDto.getEmailTemplateType());
+            emailAsyncService.sendEmailAsync(member.getEmail(), emailDto.getSubject(), emailContent, null, emailDto.getEmailTemplateType());
         } catch (MessagingException e) {
             throw new MessageSendingFailedException(member.getEmail() + " 계정 발급 안내 메일 전송에 실패했습니다.");
         }
+        emailAsyncService.processEmailQueue();
     }
 
     public void sendPasswordResetEmail(Member member, String code) {
@@ -165,105 +157,6 @@ public class EmailService {
 
         String emailTemplate = emailDto.getEmailTemplateType().getTemplateName();
         return springTemplateEngine.process(emailTemplate, context);
-    }
-
-    @Async
-    public void sendEmailAsync(String to, String subject, String content, List<File> files, EmailTemplateType emailTemplateType) throws MessagingException {
-        log.debug("Sending email to: {}", to);
-        emailQueue.add(new EmailTask(to, subject, content, files, emailTemplateType));
-    }
-
-    @Async
-    @Scheduled(fixedRate = 1000)
-    public void processEmailQueue() {
-        try {
-            List<EmailTask> batch = new ArrayList<>();
-            EmailTask task;
-            while ((task = emailQueue.poll()) != null) {
-                batch.add(task);
-                if (batch.size() >= MAX_BATCH_SIZE) {
-                    sendBatchEmail(batch);
-                    batch.clear();
-                }
-            }
-            if (!batch.isEmpty()) {
-                sendBatchEmail(batch);
-            }
-        } catch (Exception e) {
-            log.debug("Error processing email queue: {}", e.getMessage(), e);
-        }
-    }
-
-    public void sendBatchEmail(List<EmailTask> emailTasks) throws MessagingException, IOException {
-        MimeMessage[] mimeMessages = new MimeMessage[emailTasks.size()];
-        for (int i = 0; i < emailTasks.size(); i++) {
-            EmailTask task = emailTasks.get(i);
-            MimeMessage message = javaMailSender.createMimeMessage();
-            MimeMessageHelper messageHelper = new MimeMessageHelper(message, true, "UTF-8");
-            messageHelper.setFrom(sender);
-            messageHelper.setTo(task.getTo());
-            messageHelper.setSubject(task.getSubject());
-            messageHelper.setText(task.getContent(), true);
-            setImageInTemplate(messageHelper, task.getTemplateType());
-            if (task.getFiles() != null) {
-                for (File file : task.getFiles()) {
-                    messageHelper.addAttachment(MimeUtility.encodeText(file.getName(), "UTF-8", "B"), file);
-                }
-            }
-            mimeMessages[i] = message;
-        }
-
-        try {
-            javaMailSender.send(mimeMessages);
-        } catch (Exception e) {
-            log.error("Error sending batch email: " + e.getMessage(), e);
-        }
-        log.debug("Batch email sent successfully.");
-    }
-
-    protected static class EmailTask {
-        private final String to;
-        private final String subject;
-        private final String content;
-        private final List<File> files;
-        private final EmailTemplateType templateType;
-
-        public EmailTask(String to, String subject, String content, List<File> files, EmailTemplateType templateType) {
-            this.to = to;
-            this.subject = subject;
-            this.content = content;
-            this.files = files;
-            this.templateType = templateType;
-        }
-
-        public String getTo() {
-            return to;
-        }
-
-        public String getSubject() {
-            return subject;
-        }
-
-        public String getContent() {
-            return content;
-        }
-
-        public List<File> getFiles() {
-            return files;
-        }
-
-        public EmailTemplateType getTemplateType() {
-            return templateType;
-        }
-    }
-
-    private void setImageInTemplate(MimeMessageHelper messageHelper, EmailTemplateType templateType) throws MessagingException {
-        switch(templateType) {
-            case NORMAL -> {
-                messageHelper.addInline("image-1", new ClassPathResource("images/image-1.png"));
-                break;
-            }
-        }
     }
 
     private void checkDir(File file) {

--- a/src/main/java/page/clab/api/global/common/email/domain/EmailTask.java
+++ b/src/main/java/page/clab/api/global/common/email/domain/EmailTask.java
@@ -1,0 +1,22 @@
+package page.clab.api.global.common.email.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.io.File;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class EmailTask {
+
+    private final String to;
+
+    private final String subject;
+
+    private final String content;
+
+    private final List<File> files;
+
+    private final EmailTemplateType templateType;
+}


### PR DESCRIPTION
## Summary

> #368 

코드를 알아보기 쉽게 개선하고, 이메일 전송 과정에서 스케줄링을 제거하고 비동기 메소드 사용 방식을 수정했습니다.

## Tasks

- EmailTask 분리
- 스케줄링 제거
- Async 관련 메소드 사용 방식 수정 

## ETC



## Screenshot

<img width="885" alt="email1-2" src="https://github.com/KGU-C-Lab/clab-server/assets/128021502/ef5fbcd5-c54c-455d-a585-4c976a2566ab">

<img width="893" alt="전체메일전송" src="https://github.com/KGU-C-Lab/clab-server/assets/128021502/9087b5f5-34da-45d3-8e87-a3bb0b2289da">

파일 없이 메일 전송 결과
<img width="1045" alt="일반메일전송 파일 없이 실제" src="https://github.com/KGU-C-Lab/clab-server/assets/128021502/7c3021bc-793a-4f9d-aee7-61b51076f94a">
파일과 함께 메일 전송 결과
<img width="1043" alt="일반메일전송 파일 있이 실제" src="https://github.com/KGU-C-Lab/clab-server/assets/128021502/e6e4152c-253a-457c-ad39-393888302efe">
일반 메일 전송, 전체 메일 전송 둘 다 결과가 같게 나왔습니다.


