### PR TITLE
젠킨스 슬랙 알림 개선 완료

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -139,7 +139,7 @@ def sendSlackNotification(message, color) {
             "attachments": [
                 {
                     "color": "${color}",
-                    "text": "${message.replaceAll('"', '\\"').replaceAll('\n', '\\n')}"
+                    "text": "${message.replaceAll('"', '\\"').replaceAll('\n', '\\\\n')}"
                 }
             ]
         }"""

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -47,6 +47,14 @@ pipeline {
             }
         }
 
+        stage('Git 변경 이력 가져오기') {
+            steps {
+                script {
+                    env.GIT_CHANGELOG = getChangeLog()
+                }
+            }
+        }
+
         stage('PostgreSQL 백업') {
             steps {
                 script {
@@ -113,13 +121,13 @@ pipeline {
     post {
         failure {
             script {
-                sendSlackNotification(":scream_cat: Deployment failed.", env.SLACK_COLOR_FAILURE)
+                sendSlackNotification("${env.GIT_CHANGELOG}\n:scream_cat: Deployment failed.", env.SLACK_COLOR_FAILURE)
             }
         }
 
         success {
             script {
-                sendSlackNotification(":rocket: Deployment completed successfully.", env.SLACK_COLOR_SUCCESS)
+                sendSlackNotification("${env.GIT_CHANGELOG}\n:rocket: Deployment completed successfully.", env.SLACK_COLOR_SUCCESS)
             }
         }
     }
@@ -127,17 +135,36 @@ pipeline {
 
 def sendSlackNotification(message, color) {
     withEnv(["SLACK_WEBHOOK_URL=${env.SLACK_WEBHOOK_URL}"]) {
+        def payload = """{
+            "attachments": [
+                {
+                    "color": "${color}",
+                    "text": "${message.replaceAll('"', '\\"').replaceAll('\n', '\\n')}"
+                }
+            ]
+        }"""
+
         sh """
-            curl -X POST --data-urlencode 'payload={
-                "attachments": [
-                    {
-                        "color": "${color}",
-                        "text": "${message}"
-                    }
-                ]
-            }' ${SLACK_WEBHOOK_URL}
+            curl -X POST --data-urlencode 'payload=${payload}' ${SLACK_WEBHOOK_URL}
         """
     }
+}
+
+def getChangeLog() {
+    def previousCommit = env.GIT_PREVIOUS_SUCCESSFUL_COMMIT ?: 'HEAD~1'
+    def currentCommit = env.GIT_COMMIT ?: 'HEAD'
+
+    def changeLog = sh(
+        script: "git log ${previousCommit}..${currentCommit} --pretty=format:\"* %h - %s (%an)\" --abbrev-commit",
+        returnStdout: true
+    ).trim()
+
+    def lines = changeLog.split('\n')
+    if (lines.size() > 10) {
+        changeLog = lines.take(10).join('\n') + '\n... (truncated)'
+    }
+
+    return changeLog
 }
 
 def backupPostgres() {

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -2,7 +2,9 @@ pipeline {
     agent any
 
     environment {
-        SLACK_WEBHOOK_URL = credentials('slack-webhook-url')
+        SLACK_WEBHOOK_URL = credentials('slack_webhook_url')
+        SLACK_COLOR_SUCCESS = credentials('slack_color_success')
+        SLACK_COLOR_FAILURE = credentials('slack_color_failure')
 
         PG_USER = credentials('pg_user')
         PG_PASSWORD = credentials('pg_password')
@@ -40,7 +42,7 @@ pipeline {
         stage('슬랙 알림: 스테이징 서버 테스트') {
             steps {
                 script {
-                    sendSlackNotification(":test_tube: Testing the Staging server...")
+                    sendSlackNotification(":test_tube: Testing the Staging server...", env.SLACK_COLOR_SUCCESS)
                 }
             }
         }
@@ -111,21 +113,30 @@ pipeline {
     post {
         failure {
             script {
-                sendSlackNotification(":scream_cat: Deployment failed.")
+                sendSlackNotification(":scream_cat: Deployment failed.", env.SLACK_COLOR_FAILURE)
             }
         }
 
         success {
             script {
-                sendSlackNotification(":rocket: Deployment completed successfully.")
+                sendSlackNotification(":rocket: Deployment completed successfully.", env.SLACK_COLOR_SUCCESS)
             }
         }
     }
 }
 
-def sendSlackNotification(message) {
+def sendSlackNotification(message, color) {
     withEnv(["SLACK_WEBHOOK_URL=${env.SLACK_WEBHOOK_URL}"]) {
-        sh "curl -X POST --data-urlencode 'payload={\"text\": \"${message}\"}' ${SLACK_WEBHOOK_URL}"
+        sh """
+            curl -X POST --data-urlencode 'payload={
+                "attachments": [
+                    {
+                        "color": "${color}",
+                        "text": "${message}"
+                    }
+                ]
+            }' ${SLACK_WEBHOOK_URL}
+        """
     }
 }
 
@@ -137,7 +148,7 @@ def backupPostgres() {
             docker exec -e PGPASSWORD=${PG_PASSWORD} ${POSTGRESQL_CONTAINER_NAME} sh -c 'pg_dumpall -c -U ${PG_USER} > ${BACKUP_DIR}/${BACKUP_FILE}'
         """
     }
-    sendSlackNotification(":floppy_disk: PostgreSQL backup completed successfully: ${BACKUP_FILE}")
+    sendSlackNotification(":floppy_disk: PostgreSQL backup completed successfully: ${BACKUP_FILE}", env.SLACK_COLOR_SUCCESS)
 }
 
 def dockerLogin() {
@@ -202,7 +213,7 @@ def deployNewInstance() {
             docker ps -a
         """
     }
-    sendSlackNotification(":low_battery: Restarting the Staging server...")
+    sendSlackNotification(":low_battery: Restarting the Staging server...", env.SLACK_COLOR_SUCCESS)
 }
 
 def performHealthCheck() {
@@ -223,7 +234,7 @@ def performHealthCheck() {
     }
 
     if (System.currentTimeMillis() >= timeout) {
-        sendSlackNotification(":scream_cat: New Staging application did not start successfully within 4 minutes.")
+        sendSlackNotification(":scream_cat: New Staging application did not start successfully within 4 minutes.", env.SLACK_COLOR_FAILURE)
         sh "docker stop ${env.DEPLOY_CONTAINER}"
         sh "docker rm ${env.DEPLOY_CONTAINER}"
         error "Health check failed"


### PR DESCRIPTION
## Summary

> #370 

[1]
서버 환경에 따라 Attachment color를 설정하여 알림을 구분할 수 있도록 합니다.

[2]
빌드 성공/실패 여부를 보다 쉽게 구분하기 위해 메시지의 색상을 부여합니다.

[3]
Git 변경 사항을 출력합니다.

## Tasks

- Slack Message에 Attachment 추가
- Jenkins Credentials에 슬랙 메시지 색상 추가
- Git 변경 사항을 가져와 출력하도록 함

## ETC

## Screenshot
![image](https://github.com/KGU-C-Lab/clab-server/assets/85067003/105bb535-bf5a-4e84-bd48-f93c8b6aa8a3)
