### PR TITLE
일정 조회가 되지 않는 현상 해결

### DIFF
--- a/src/main/java/page/clab/api/domain/schedule/application/ScheduleService.java
+++ b/src/main/java/page/clab/api/domain/schedule/application/ScheduleService.java
@@ -117,7 +117,6 @@ public class ScheduleService {
     public List<ActivityGroup> getMyActivityGroups(List<GroupMember> groupMembers) {
         return groupMembers.stream()
                 .map(GroupMember::getActivityGroup)
-                .distinct()
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/page/clab/api/domain/schedule/application/ScheduleService.java
+++ b/src/main/java/page/clab/api/domain/schedule/application/ScheduleService.java
@@ -2,7 +2,6 @@ package page.clab.api.domain.schedule.application;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -26,7 +25,6 @@ import page.clab.api.global.exception.NotFoundException;
 import page.clab.api.global.exception.PermissionDeniedException;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/src/main/java/page/clab/api/domain/schedule/dao/ScheduleRepositoryCustom.java
+++ b/src/main/java/page/clab/api/domain/schedule/dao/ScheduleRepositoryCustom.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 public interface ScheduleRepositoryCustom {
 
-    Page<Schedule> findByDateRangeAndMember(LocalDate startDate, LocalDate endDate, List<ActivityGroup> myGroupList, Pageable pageable);
+    Page<Schedule> findByDateRangeAndMember(LocalDate startDate, LocalDate endDate, List<ActivityGroup> myGroups, Pageable pageable);
 
     Page<Schedule> findByConditions(Integer year, Integer month, SchedulePriority priority, Pageable pageable);
 

--- a/src/main/java/page/clab/api/domain/schedule/dao/ScheduleRepositoryCustom.java
+++ b/src/main/java/page/clab/api/domain/schedule/dao/ScheduleRepositoryCustom.java
@@ -2,16 +2,18 @@ package page.clab.api.domain.schedule.dao;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import page.clab.api.domain.activityGroup.domain.ActivityGroup;
 import page.clab.api.domain.member.domain.Member;
 import page.clab.api.domain.schedule.domain.Schedule;
 import page.clab.api.domain.schedule.domain.SchedulePriority;
 import page.clab.api.domain.schedule.dto.response.ScheduleCollectResponseDto;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public interface ScheduleRepositoryCustom {
 
-    Page<Schedule> findByDateRangeAndMember(LocalDate startDate, LocalDate endDate, Member member, Pageable pageable);
+    Page<Schedule> findByDateRangeAndMember(LocalDate startDate, LocalDate endDate, List<ActivityGroup> myGroupList, Pageable pageable);
 
     Page<Schedule> findByConditions(Integer year, Integer month, SchedulePriority priority, Pageable pageable);
 

--- a/src/main/java/page/clab/api/domain/schedule/dao/ScheduleRepositoryImpl.java
+++ b/src/main/java/page/clab/api/domain/schedule/dao/ScheduleRepositoryImpl.java
@@ -27,7 +27,7 @@ public class ScheduleRepositoryImpl implements ScheduleRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Schedule> findByDateRangeAndMember(LocalDate startDate, LocalDate endDate, List<ActivityGroup> myGroupList, Pageable pageable) {
+    public Page<Schedule> findByDateRangeAndMember(LocalDate startDate, LocalDate endDate, List<ActivityGroup> myGroups, Pageable pageable) {
         QSchedule schedule = QSchedule.schedule;
         BooleanBuilder builder = new BooleanBuilder();
 
@@ -37,9 +37,9 @@ public class ScheduleRepositoryImpl implements ScheduleRepositoryCustom {
         builder.and(schedule.endDateTime.goe(startDateTime))
                 .and(schedule.startDateTime.loe(endDateTime));
 
-        if (myGroupList != null && !myGroupList.isEmpty()) {
+        if (myGroups != null && !myGroups.isEmpty()) {
             builder.and(schedule.activityGroup.isNull()
-                    .or(schedule.activityGroup.in(myGroupList)));
+                    .or(schedule.activityGroup.in(myGroups)));
         } else {
             builder.and(schedule.activityGroup.isNull());
         }


### PR DESCRIPTION
## Summary

> #371 

일정 조회 시 자신이 등록하지 않은 일정이 조회가 되지 않는 현상을 해결했습니다.

## Tasks

- ScheduleType이 ALL인 일정을 조회합니다.
- ScheduleType이 Study이거나 Project일 때 본인이 포함된 활동의 일정을 조회합니다.

## ETC

DAO에서 쿼리문을 작성할 때, where절에 currentMember가 포함되도록 작성되어 있어 발생한 문제였습니다.

## Screenshot

<img width="626" alt="db" src="https://github.com/KGU-C-Lab/clab-server/assets/128021502/b8f34849-c840-4495-9ed7-8877fffe43d0">

이와 같이 superuser가 생성한 일정이 DB에 저장되어 있을 때,

<img width="1048" alt="완성적 요청" src="https://github.com/KGU-C-Lab/clab-server/assets/128021502/5c5ad05f-8c58-4f78-a9b6-2d3edade12b6">

일반 회원이 일정을 조회하면 본인이 활동 중인 C 스터디 하나만 조회가 되고, ScheduleType이 ALL인 모든 일정이 조회됩니다.

```json
{
  "success": true,
  "data": {
    "currentPage": 0,
    "hasPrevious": false,
    "hasNext": false,
    "totalPages": 1,
    "totalItems": 6,
    "take": 6,
    "items": [
      {
        "id": 10,
        "title": "코어팀 2기 면접",
        "detail": "C-Lab Core Team 2기 (Front, Back)의 대면 면접이 있습니다. 13:00~13:50 동안 진행되며 팀당 약 10분씩 소요될 예정입니다.",
        "activityName": null,
        "startDate": "2024-05-27T13:00:00",
        "endDate": "2024-05-27T13:50:00",
        "priority": "HIGH"
      },
      {
        "id": 11,
        "title": "코어팀 2기 합격 발표",
        "detail": "C-Lab Core Team 2기 (Front, Back) 합격 발표날입니다!",
        "activityName": null,
        "startDate": "2024-05-28T10:00:00",
        "endDate": "2024-05-28T11:00:00",
        "priority": "HIGH"
      },
      {
        "id": 12,
        "title": "24년도 1학기 C-Lab 종강총회",
        "detail": "24년도 1학기 C-Lab 종강총회를 진행합니다.",
        "activityName": null,
        "startDate": "2024-06-14T17:30:00",
        "endDate": "2024-06-14T21:00:00",
        "priority": "HIGH"
      },
      {
        "id": 14,
        "title": "202014941이 등록한 일정",
        "detail": "202014941이 등록한 일정입니다",
        "activityName": null,
        "startDate": "2024-06-20T09:00:00",
        "endDate": "2024-06-21T23:00:00",
        "priority": "HIGH"
      },
      {
        "id": 15,
        "title": "C 스터디",
        "detail": "0627 C 스터디",
        "activityName": "2024-1 신입생 대상 C언어 스터디",
        "startDate": "2024-06-27T09:00:00",
        "endDate": "2024-06-27T23:00:00",
        "priority": "HIGH"
      },
      {
        "id": 13,
        "title": "24년 C-Lab 여름MT",
        "detail": "대부도 펜션벨리에서, 1박 2일간 여름 MT를 진행합니다.",
        "activityName": null,
        "startDate": "2024-07-01T09:00:00",
        "endDate": "2024-07-02T23:00:00",
        "priority": "HIGH"
      }
    ]
  }
}
```
