### PR TITLE
지원단위별 계정 통합 생성 시 이메일이 보내지지 않는 현상 해결

### DIFF
--- a/src/main/java/page/clab/api/global/common/email/application/EmailAsyncService.java
+++ b/src/main/java/page/clab/api/global/common/email/application/EmailAsyncService.java
@@ -10,6 +10,7 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import page.clab.api.global.common.email.domain.EmailTask;
 import page.clab.api.global.common.email.domain.EmailTemplateType;
@@ -42,6 +43,7 @@ public class EmailAsyncService {
     }
 
     @Async
+    @Scheduled(fixedRate = 1000)
     public void processEmailQueue() {
         try {
             List<EmailTask> batch = new ArrayList<>();

--- a/src/main/java/page/clab/api/global/common/email/application/EmailAsyncService.java
+++ b/src/main/java/page/clab/api/global/common/email/application/EmailAsyncService.java
@@ -18,8 +18,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-
-import static page.clab.api.global.common.email.application.EmailService.emailQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 
 @Service
 @Slf4j
@@ -32,6 +32,8 @@ public class EmailAsyncService {
     private String sender;
 
     private static final int MAX_BATCH_SIZE = 10;
+
+    private static final BlockingQueue<EmailTask> emailQueue = new LinkedBlockingQueue<>();
 
     @Async
     public void sendEmailAsync(String to, String subject, String content, List<File> files, EmailTemplateType emailTemplateType) throws MessagingException {

--- a/src/main/java/page/clab/api/global/common/email/application/EmailService.java
+++ b/src/main/java/page/clab/api/global/common/email/application/EmailService.java
@@ -12,7 +12,6 @@ import org.thymeleaf.spring6.SpringTemplateEngine;
 import page.clab.api.domain.member.application.MemberService;
 import page.clab.api.domain.member.domain.Member;
 import page.clab.api.domain.member.dto.response.MemberResponseDto;
-import page.clab.api.global.common.email.domain.EmailTask;
 import page.clab.api.global.common.email.domain.EmailTemplateType;
 import page.clab.api.global.common.email.dto.request.EmailDto;
 import page.clab.api.global.common.email.exception.MessageSendingFailedException;
@@ -23,8 +22,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
 
 @Service
 @RequiredArgsConstructor
@@ -39,8 +36,6 @@ public class EmailService {
 
     @Value("${resource.file.path}")
     private String filePath;
-
-    protected static final BlockingQueue<EmailTask> emailQueue = new LinkedBlockingQueue<>();
 
     public List<String> broadcastEmail(EmailDto emailDto, List<MultipartFile> multipartFiles) {
         List<File> convertedFiles = multipartFiles != null && !multipartFiles.isEmpty()

--- a/src/main/java/page/clab/api/global/common/email/application/EmailService.java
+++ b/src/main/java/page/clab/api/global/common/email/application/EmailService.java
@@ -54,7 +54,6 @@ public class EmailService {
                 throw new MessageSendingFailedException(address + "에게 이메일을 보내는데 실패했습니다.");
             }
         });
-        emailAsyncService.processEmailQueue();
         return successfulAddresses;
     }
 
@@ -75,7 +74,6 @@ public class EmailService {
                 throw new MessageSendingFailedException(member.getEmail() + "에게 이메일을 보내는데 실패했습니다.");
             }
         });
-        emailAsyncService.processEmailQueue();
         return successfulEmails;
     }
 
@@ -99,7 +97,6 @@ public class EmailService {
         } catch (MessagingException e) {
             throw new MessageSendingFailedException(member.getEmail() + " 계정 발급 안내 메일 전송에 실패했습니다.");
         }
-        emailAsyncService.processEmailQueue();
     }
 
     public void sendPasswordResetEmail(Member member, String code) {


### PR DESCRIPTION
## Summary

> #375 

지원 단위 별로 합격자 계정 통합 생성시 이메일이 정상적으로 보내지지 않는 현상을 해결했습니다.

## Tasks

- EmailService에 있던 emailQueue를, 실제 사용하는 EmailAsyncService로 옮깁니다.
- processEmileQueue에 스케줄러를 다시 도입합니다.

## ETC

이전에 해당 부분을 리팩토링했을 때, 시스템 성능을 위해 스프링의 스케줄러를 삭제했습니다. 하지만 스케줄러를 삭제하니 EmailTask가 emailQueue에 저장되었다가 processEmailQueue 메소드에 의해 실제 이메일이 전송되는 과정에서, 비동기로 실행하기 때문에 다른 비동기 작업들이 완료되지 않아 첫 api 호출에서 이메일 큐의 내용을 처리하지 못하는 문제로 발생한 버그로 인지했습니다. 
따라서 다시 스프링 스케줄러를 도입해 비동기 메소드를 주기적으로 호출해 큐에 남아있는 이메일들을 계속해서 전송하는 방식으로 변경했습니다.

## Screenshot

여러 번 계정 삭제 및 반복으로 전송을 시도했을 때, 잘 전송이 되는 것을 볼 수 있습니다.
![스크린샷 2024-06-15 132717](https://github.com/KGU-C-Lab/clab-server/assets/128021502/f64b47ea-01b5-412e-ade7-05e07e706424)


