### PR TITLE
젠킨스 웹훅 미작동 오류 수정 완료

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -5,7 +5,6 @@ pipeline {
         githubPush()
     }
 
-
     environment {
         JENKINS_DOMAIN = credentials('jenkins_domain')
 

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,6 +1,10 @@
 pipeline {
     agent any
 
+    triggers {
+        githubPush()
+    }
+
     environment {
         JENKINS_DOMAIN = credentials('jenkins_domain')
 

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -5,6 +5,7 @@ pipeline {
         githubPush()
     }
 
+
     environment {
         JENKINS_DOMAIN = credentials('jenkins_domain')
 


### PR DESCRIPTION
## Summary

> #383 

젠킨스를 Freestyle에서 Pipeline으로 마이그레이션한 이후, 웹훅이 정상적으로 작동하지 않습니다.
브랜치의 변경 사항을 감지하고 자동으로 빌드 및 배포할 수 있도록 오류를 수정합니다.

## Tasks

- Jenkinsfile에 트리거를 추가하여 Github Webhook이 정상 작동하도록 수정
- Jenkins 접근 제어로 인한 웹훅 푸시 오류 수정

## ETC
[1]
Freestyle과 달리 Pipeline에서는 Jenkinsfile에서 트리거를 추가해야만 정상적으로 Webhook을 수신하고 빌드합니다. Pipeline에 아래 코드를 추가함으로써 문제를 해결합니다.
```
triggers {
    githubPush()
}
```

[2]
지난 #348 작업을 하며 Nginx에서 Jenkins와 Grafana 서비스에 대한 접근 권한을 수정하였습니다. 해당 작업 이후, Github Webhook의 요청이 Nginx에서 차단되는 문제가 발생하였으며, Whitelist에 Github가 사용하는 IP 대역을 추가하여 해결했습니다.
[Jenkins 접근 제어로 인한 깃허브 웹훅 연결 오류 문제 수정](https://github.com/KGU-C-Lab/core-team/commit/db083284d1dcb35b92d4a052e5a057f51934f725)

## Screenshot
![image](https://github.com/KGU-C-Lab/clab-server/assets/85067003/03a9245d-8a67-486d-b432-9e05da6811df)