### PR TITLE
모집공고 상태 자동변경 로직 작성 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/recruitment/application/RecruitmentService.java
+++ b/src/main/java/page/clab/api/domain/recruitment/application/RecruitmentService.java
@@ -1,13 +1,19 @@
 package page.clab.api.domain.recruitment.application;
 
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.annotation.Transactional;
 import page.clab.api.domain.notification.application.NotificationService;
 import page.clab.api.domain.recruitment.dao.RecruitmentRepository;
 import page.clab.api.domain.recruitment.domain.Recruitment;
+import page.clab.api.domain.recruitment.domain.RecruitmentStatus;
 import page.clab.api.domain.recruitment.dto.request.RecruitmentRequestDto;
 import page.clab.api.domain.recruitment.dto.request.RecruitmentUpdateRequestDto;
 import page.clab.api.domain.recruitment.dto.response.RecruitmentResponseDto;
@@ -15,6 +21,7 @@ import page.clab.api.global.common.dto.PagedResponseDto;
 import page.clab.api.global.exception.NotFoundException;
 import page.clab.api.global.validation.ValidationService;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -27,9 +34,16 @@ public class RecruitmentService {
 
     private final RecruitmentRepository recruitmentRepository;
 
+    private final PlatformTransactionManager transactionManager;
+
+    private final EntityManager entityManager;
+
+    private final TransactionDefinition transactionDefinition;
+
     @Transactional
     public Long createRecruitment(RecruitmentRequestDto requestDto) {
         Recruitment recruitment = RecruitmentRequestDto.toEntity(requestDto);
+        updateRecruitmentStatusByRecruitment(recruitment);
         validationService.checkValid(recruitment);
         notificationService.sendNotificationToAllMembers("새로운 모집 공고가 등록되었습니다.");
         return recruitmentRepository.save(recruitment).getId();
@@ -67,6 +81,23 @@ public class RecruitmentService {
     public Recruitment getRecruitmentByIdOrThrow(Long recruitmentId) {
         return recruitmentRepository.findById(recruitmentId)
                 .orElseThrow(() -> new NotFoundException("해당 모집 공고가 존재하지 않습니다."));
+    }
+
+    @Scheduled(cron = "0 * * * * *")
+    public void updateRecruitmentStatus(){
+        List<Recruitment> recruitments = recruitmentRepository.findAll();
+        recruitments.forEach(this::updateRecruitmentStatusByRecruitment);
+    }
+
+    public void updateRecruitmentStatusByRecruitment(Recruitment recruitment){
+        TransactionStatus transactionStatus = transactionManager.getTransaction(transactionDefinition);
+        LocalDateTime now = LocalDateTime.now();
+        RecruitmentStatus newStatus = now.isBefore(recruitment.getStartDate())
+                ? RecruitmentStatus.UPCOMING : now.isAfter(recruitment.getEndDate())
+                    ? RecruitmentStatus.CLOSED : RecruitmentStatus.OPEN;
+        recruitment.updateStatus(newStatus);
+        entityManager.merge(recruitment);
+        transactionManager.commit(transactionStatus);
     }
 
 }

--- a/src/main/java/page/clab/api/domain/recruitment/application/RecruitmentService.java
+++ b/src/main/java/page/clab/api/domain/recruitment/application/RecruitmentService.java
@@ -94,9 +94,9 @@ public class RecruitmentService {
         TransactionStatus transactionStatus = transactionManager.getTransaction(transactionDefinition);
         LocalDateTime now = LocalDateTime.now();
         RecruitmentStatus newStatus = RecruitmentStatus.OPEN;
-        if(now.isBefore(recruitment.getStartDate())){
+        if (now.isBefore(recruitment.getStartDate())) {
             newStatus = RecruitmentStatus.UPCOMING;
-        }else if(now.isAfter(recruitment.getEndDate())){
+        } else if(now.isAfter(recruitment.getEndDate())) {
             newStatus = RecruitmentStatus.CLOSED;
         }
         recruitment.updateStatus(newStatus);

--- a/src/main/java/page/clab/api/domain/recruitment/application/RecruitmentService.java
+++ b/src/main/java/page/clab/api/domain/recruitment/application/RecruitmentService.java
@@ -69,6 +69,7 @@ public class RecruitmentService {
         Recruitment recruitment = getRecruitmentByIdOrThrow(recruitmentId);
         recruitment.update(requestDto);
         validationService.checkValid(recruitment);
+        updateRecruitmentStatusByRecruitment(recruitment);
         return recruitmentRepository.save(recruitment).getId();
     }
 
@@ -92,9 +93,12 @@ public class RecruitmentService {
     public void updateRecruitmentStatusByRecruitment(Recruitment recruitment){
         TransactionStatus transactionStatus = transactionManager.getTransaction(transactionDefinition);
         LocalDateTime now = LocalDateTime.now();
-        RecruitmentStatus newStatus = now.isBefore(recruitment.getStartDate())
-                ? RecruitmentStatus.UPCOMING : now.isAfter(recruitment.getEndDate())
-                    ? RecruitmentStatus.CLOSED : RecruitmentStatus.OPEN;
+        RecruitmentStatus newStatus = RecruitmentStatus.OPEN;
+        if(now.isBefore(recruitment.getStartDate())){
+            newStatus = RecruitmentStatus.UPCOMING;
+        }else if(now.isAfter(recruitment.getEndDate())){
+            newStatus = RecruitmentStatus.CLOSED;
+        }
         recruitment.updateStatus(newStatus);
         entityManager.merge(recruitment);
         transactionManager.commit(transactionStatus);

--- a/src/main/java/page/clab/api/domain/recruitment/domain/Recruitment.java
+++ b/src/main/java/page/clab/api/domain/recruitment/domain/Recruitment.java
@@ -52,15 +52,16 @@ public class Recruitment extends BaseEntity {
     private String target;
 
     @Column(nullable = false)
-    @Size(min = 1, message = "{size.recruitment.status}")
-    private String status;
+    @Enumerated(EnumType.STRING)
+    private RecruitmentStatus status;
 
     public void update(RecruitmentUpdateRequestDto recruitmentUpdateRequestDto) {
         Optional.ofNullable(recruitmentUpdateRequestDto.getStartDate()).ifPresent(this::setStartDate);
         Optional.ofNullable(recruitmentUpdateRequestDto.getEndDate()).ifPresent(this::setEndDate);
         Optional.ofNullable(recruitmentUpdateRequestDto.getApplicationType()).ifPresent(this::setApplicationType);
         Optional.ofNullable(recruitmentUpdateRequestDto.getTarget()).ifPresent(this::setTarget);
-        Optional.ofNullable(recruitmentUpdateRequestDto.getStatus()).ifPresent(this::setStatus);
     }
+
+    public void updateStatus(RecruitmentStatus status) { this.status = status; }
 
 }

--- a/src/main/java/page/clab/api/domain/recruitment/domain/RecruitmentStatus.java
+++ b/src/main/java/page/clab/api/domain/recruitment/domain/RecruitmentStatus.java
@@ -1,0 +1,17 @@
+package page.clab.api.domain.recruitment.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum RecruitmentStatus {
+
+    UPCOMING("UPCOMING", "모집 예정"),
+    OPEN("OPEN", "모집중"),
+    CLOSED("CLOSED", "모집 종료");
+
+    private String key;
+    private String description;
+
+}

--- a/src/main/java/page/clab/api/domain/recruitment/dto/request/RecruitmentRequestDto.java
+++ b/src/main/java/page/clab/api/domain/recruitment/dto/request/RecruitmentRequestDto.java
@@ -29,17 +29,12 @@ public class RecruitmentRequestDto {
     @Schema(description = "대상", example = "2~3학년", required = true)
     private String target;
 
-    @NotNull(message = "{notNull.recruitment.status}")
-    @Schema(description = "상태", example = "종료", required = true)
-    private String status;
-
     public static Recruitment toEntity(RecruitmentRequestDto requestDto) {
         return Recruitment.builder()
                 .startDate(requestDto.getStartDate())
                 .endDate(requestDto.getEndDate())
                 .applicationType(requestDto.getApplicationType())
                 .target(requestDto.getTarget())
-                .status(requestDto.getStatus())
                 .build();
     }
 

--- a/src/main/java/page/clab/api/domain/recruitment/dto/request/RecruitmentUpdateRequestDto.java
+++ b/src/main/java/page/clab/api/domain/recruitment/dto/request/RecruitmentUpdateRequestDto.java
@@ -23,7 +23,4 @@ public class RecruitmentUpdateRequestDto {
     @Schema(description = "대상", example = "2~3학년")
     private String target;
 
-    @Schema(description = "상태", example = "종료")
-    private String status;
-
 }

--- a/src/main/java/page/clab/api/domain/recruitment/dto/response/RecruitmentResponseDto.java
+++ b/src/main/java/page/clab/api/domain/recruitment/dto/response/RecruitmentResponseDto.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 import page.clab.api.domain.application.domain.ApplicationType;
 import page.clab.api.domain.recruitment.domain.Recruitment;
+import page.clab.api.domain.recruitment.domain.RecruitmentStatus;
 
 import java.time.LocalDateTime;
 
@@ -21,7 +22,7 @@ public class RecruitmentResponseDto {
 
     private String target;
 
-    private String status;
+    private RecruitmentStatus status;
 
     private LocalDateTime updatedAt;
 

--- a/src/main/java/page/clab/api/global/config/TransactionConfig.java
+++ b/src/main/java/page/clab/api/global/config/TransactionConfig.java
@@ -9,7 +9,7 @@ import org.springframework.transaction.support.DefaultTransactionDefinition;
 public class TransactionConfig {
 
     @Bean
-    public TransactionDefinition transactionDefinition(){
+    public TransactionDefinition transactionDefinition() {
         return new DefaultTransactionDefinition();
     }
 

--- a/src/main/java/page/clab/api/global/config/TransactionConfig.java
+++ b/src/main/java/page/clab/api/global/config/TransactionConfig.java
@@ -1,0 +1,16 @@
+package page.clab.api.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+
+@Configuration
+public class TransactionConfig {
+
+    @Bean
+    public TransactionDefinition transactionDefinition(){
+        return new DefaultTransactionDefinition();
+    }
+
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -44,7 +44,6 @@ size.product.name=서비스명은 최소 {min}글자 이상이어야 합니다.
 size.product.description=설명은 최소 {min}글자에서 {max}글자 사이어야 합니다.
 size.recruitment.applicationType=신청 유형은 최소 {min}자 이상이어야 합니다.
 size.recruitment.target=대상은 최소 {min}자 이상이어야 합니다.
-size.recruitment.status=상태는 최소 {min}자 이상이어야 합니다.
 size.review.content=내용은 {min}자 이상 {max}자 이하여야 합니다.
 size.sharedAccount.username=유저명은 {min}자 이상이어야 합니다.
 size.sharedAccount.password=비밀번호는 {min}자 이상이어야 합니다.


### PR DESCRIPTION
## Summary

> #353

원래 모집 공고의 상태를 직접 String으로 수정해야 하는 문제점이 있었습니다.
따라서 모집 시작 시각, 모집 종료 시각을 기준으로 모집 공고의 상태를 자동으로 변경하는 로직을 구현했습니다.

## Tasks

- 모집 공고 상태 enum 마련
- 모집 공고 상태 자동 변경 스케줄링 구현

## ETC

스케줄링을 사용하는 로직에서 Transaction 어노테이션을 적용하면, 변경 객체가 준영속상태가 되는 문제가 있었습니다.
따라서 스케줄링 로직과 Transaction 어노테이션이 동시에 돌아가지 않는 이슈로 인해 직접 객체의 변경 사항을 커밋했습니다.

## Screenshot

*현재시각 < 모집 시작시각*
![스크린샷 2024-06-24 233354](https://github.com/KGU-C-Lab/clab-server/assets/128021502/cbd17fdc-9a25-4dc8-860e-976427a53f3a)

*모집 시작시각 < 현재시각 < 모집 종료시각*
![스크린샷 2024-06-24 233705](https://github.com/KGU-C-Lab/clab-server/assets/128021502/16d1a8be-7902-4c1e-afd9-92e87b191b66)

*현재시각 > 모집 종료시각*
![스크린샷 2024-06-25 000214](https://github.com/KGU-C-Lab/clab-server/assets/128021502/e3381ff7-bb90-4afe-8fd1-699c74680b26)

*모집공고 조회*
![스크린샷 2024-06-25 004438](https://github.com/KGU-C-Lab/clab-server/assets/128021502/88a48bb2-537b-4927-b678-d6dcd273f89d)

*모집공고 일정 수정 전*
![스크린샷 2024-06-25 212236](https://github.com/KGU-C-Lab/clab-server/assets/128021502/8ceee374-0e71-4006-82d1-f32d4586a4ab)
![스크린샷 2024-06-25 212328](https://github.com/KGU-C-Lab/clab-server/assets/128021502/10070fc4-326b-46dc-9caa-f61cddd6df05)
![스크린샷 2024-06-25 212432](https://github.com/KGU-C-Lab/clab-server/assets/128021502/962f15e6-821e-4232-8c31-f4cb23584fe5)

*모집공고 일정 수정 후(기간 연장)*
![스크린샷 2024-06-25 212625](https://github.com/KGU-C-Lab/clab-server/assets/128021502/4c8de498-d50e-4348-9cef-325085406fa8)
-> 다시 open 상태로 즉각 변경됨



