### PR TITLE
모집 공고 상태 응답값 변경 완료

### DIFF
--- a/src/main/java/page/clab/api/domain/recruitment/domain/RecruitmentStatus.java
+++ b/src/main/java/page/clab/api/domain/recruitment/domain/RecruitmentStatus.java
@@ -8,8 +8,8 @@ import lombok.Getter;
 public enum RecruitmentStatus {
 
     UPCOMING("UPCOMING", "모집 예정"),
-    OPEN("OPEN", "모집중"),
-    CLOSED("CLOSED", "모집 종료");
+    OPEN("OPEN", "진행중"),
+    CLOSED("CLOSED", "종료");
 
     private String key;
     private String description;

--- a/src/main/java/page/clab/api/domain/recruitment/dto/response/RecruitmentResponseDto.java
+++ b/src/main/java/page/clab/api/domain/recruitment/dto/response/RecruitmentResponseDto.java
@@ -22,7 +22,7 @@ public class RecruitmentResponseDto {
 
     private String target;
 
-    private RecruitmentStatus status;
+    private String status;
 
     private LocalDateTime updatedAt;
 
@@ -33,7 +33,7 @@ public class RecruitmentResponseDto {
                 .endDate(recruitment.getEndDate())
                 .applicationType(recruitment.getApplicationType())
                 .target(recruitment.getTarget())
-                .status(recruitment.getStatus())
+                .status(recruitment.getStatus().getDescription())
                 .updatedAt(recruitment.getUpdatedAt())
                 .build();
     }


### PR DESCRIPTION
## Summary

> #393 

클라이언트에서 현재 모집공고 상태의 key를 다른 값으로 매핑하지 못하는 문제로 인해, 
응답으로 discription을 반환하는 것으로 수정했습니다.

## Tasks

- RecruitmentStatus의 discription 변경
- RecruitmentResponseDto의 status 값을 discription으로 반환

## ETC


## Screenshot

![스크린샷 2024-06-27 104038](https://github.com/KGU-C-Lab/clab-server/assets/128021502/7adc721f-b7d2-4216-b7ae-457c0d57f24d)


