### PR TITLE
의존성 업데이트로 인한 JWT 파싱 오류 수정 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     // Security
     implementation 'org.springframework.boot:spring-boot-starter-security' // Spring Security
     implementation 'com.warrenstrange:googleauth:1.5.0' // Google Authenticator
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.5' // JWT 라이브러리
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6' // JWT 라이브러리
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6' // JWT 구현체
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6' // JWT Jackson 모듈
 

--- a/src/main/java/page/clab/api/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/page/clab/api/global/auth/jwt/JwtTokenProvider.java
@@ -112,7 +112,7 @@ public class JwtTokenProvider {
 
     public boolean validateToken(String token) {
         try {
-            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            Jwts.parser().setSigningKey(key).build().parseClaimsJws(token);
             return true;
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
             log.info("Invalid JWT Token");
@@ -128,7 +128,7 @@ public class JwtTokenProvider {
 
     public boolean validateTokenSilently(String token) {
         try {
-            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            Jwts.parser().setSigningKey(key).build().parseClaimsJws(token);
             return true;
         } catch (Exception e) {
             return false;
@@ -137,7 +137,7 @@ public class JwtTokenProvider {
 
     public Claims parseClaims(String accessToken) {
         try {
-            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+            return Jwts.parser().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
         } catch (ExpiredJwtException e) {
             return e.getClaims();
         }


### PR DESCRIPTION
## Summary

> #420

- Dependabot에 의해 io.jsonwebtoken:jjwt 의존성이 0.11.5에서 0.12.6으로 업데이트되었습니다.
- 업데이트 이후, 서버 로그인 과정에서 Jwts.parserBuilder()가 Jwts.parser()로 변경되면서 로그인 오류가 발생했습니다.
- 이 PR은 해당 변경 사항을 반영하고, 로그인 오류를 해결하기 위한 수정 사항을 포함하고 있습니다.

## Tasks

- `Jwts.parserBuilder()`를 `Jwts.parser()`로 변경된 사항 수정
- JWT 파싱 및 검증 로직 수정