### PR TITLE
커뮤니티 게시글 작성자가 로그인 된 본인으로 응답되는 버그 해결

### DIFF
--- a/src/main/java/page/clab/api/domain/community/board/application/service/BoardDetailsRetrievalService.java
+++ b/src/main/java/page/clab/api/domain/community/board/application/service/BoardDetailsRetrievalService.java
@@ -29,9 +29,10 @@ public class BoardDetailsRetrievalService implements RetrieveBoardDetailsUseCase
     public BoardDetailsResponseDto retrieveBoardDetails(Long boardId) {
         MemberDetailedInfoDto currentMemberInfo = externalRetrieveMemberUseCase.getCurrentMemberDetailedInfo();
         Board board = retrieveBoardPort.findByIdOrThrow(boardId);
+        MemberDetailedInfoDto memberInfo = externalRetrieveMemberUseCase.getMemberDetailedInfoById(board.getMemberId());
         boolean isOwner = board.isOwner(currentMemberInfo.getMemberId());
         List<BoardEmojiCountResponseDto> emojiInfos = getBoardEmojiCountResponseDtoList(boardId, currentMemberInfo.getMemberId());
-        return BoardDetailsResponseDto.toDto(board, currentMemberInfo, isOwner, emojiInfos);
+        return BoardDetailsResponseDto.toDto(board, memberInfo, isOwner, emojiInfos);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/page/clab/api/domain/community/board/application/service/BoardRetrievalService.java
+++ b/src/main/java/page/clab/api/domain/community/board/application/service/BoardRetrievalService.java
@@ -26,14 +26,18 @@ public class BoardRetrievalService implements RetrieveBoardUseCase {
     @Transactional
     @Override
     public PagedResponseDto<BoardListResponseDto> retrieveBoards(Pageable pageable) {
-        MemberDetailedInfoDto currentMemberInfo = externalRetrieveMemberUseCase.getCurrentMemberDetailedInfo();
         Page<Board> boards = retrieveBoardPort.findAll(pageable);
-        return new PagedResponseDto<>(boards.map(board -> mapToBoardListResponseDto(board, currentMemberInfo)));
+        return new PagedResponseDto<>(boards.map(board ->
+                mapToBoardListResponseDto(board, getMemberDetailedInfoByBoard(board))));
     }
 
     @Override
     public Board findByIdOrThrow(Long boardId) {
         return retrieveBoardPort.findByIdOrThrow(boardId);
+    }
+
+    private MemberDetailedInfoDto getMemberDetailedInfoByBoard(Board board) {
+        return externalRetrieveMemberUseCase.getMemberDetailedInfoById(board.getMemberId());
     }
 
     @NotNull

--- a/src/main/java/page/clab/api/domain/community/board/application/service/BoardsByCategoryRetrievalService.java
+++ b/src/main/java/page/clab/api/domain/community/board/application/service/BoardsByCategoryRetrievalService.java
@@ -26,11 +26,14 @@ public class BoardsByCategoryRetrievalService implements RetrieveBoardsByCategor
     @Transactional
     @Override
     public PagedResponseDto<BoardCategoryResponseDto> retrieveBoardsByCategory(BoardCategory category, Pageable pageable) {
-        MemberDetailedInfoDto currentMemberInfo = externalRetrieveMemberUseCase.getCurrentMemberDetailedInfo();
         Page<Board> boards = retrieveBoardPort.findAllByCategory(category, pageable);
         return new PagedResponseDto<>(boards.map(board -> {
             long commentCount = externalRetrieveCommentUseCase.countByBoardId(board.getId());
-            return  BoardCategoryResponseDto.toDto(board, currentMemberInfo, commentCount);
+            return  BoardCategoryResponseDto.toDto(board, getMemberDetailedInfoByBoard(board), commentCount);
         }));
+    }
+
+    private MemberDetailedInfoDto getMemberDetailedInfoByBoard(Board board) {
+        return externalRetrieveMemberUseCase.getMemberDetailedInfoById(board.getMemberId());
     }
 }

--- a/src/main/java/page/clab/api/domain/community/board/application/service/DeletedBoardsRetrievalService.java
+++ b/src/main/java/page/clab/api/domain/community/board/application/service/DeletedBoardsRetrievalService.java
@@ -26,9 +26,13 @@ public class DeletedBoardsRetrievalService implements RetrieveDeletedBoardsUseCa
     @Transactional(readOnly = true)
     @Override
     public PagedResponseDto<BoardListResponseDto> retrieveDeletedBoards(Pageable pageable) {
-        MemberDetailedInfoDto currentMemberInfo = externalRetrieveMemberUseCase.getCurrentMemberDetailedInfo();
         Page<Board> boards = retrieveBoardPort.findAllByIsDeletedTrue(pageable);
-        return new PagedResponseDto<>(boards.map(board -> mapToBoardListResponseDto(board, currentMemberInfo)));
+        return new PagedResponseDto<>(boards.map(board ->
+                mapToBoardListResponseDto(board, getMemberDetailedInfoByBoard(board))));
+    }
+
+    private MemberDetailedInfoDto getMemberDetailedInfoByBoard(Board board) {
+        return externalRetrieveMemberUseCase.getMemberDetailedInfoById(board.getMemberId());
     }
 
     @NotNull


### PR DESCRIPTION
## Summary

> #422 

`BoardRetrievalService`, `DeletedBoardsRetrievalService`, `BoardsByCategoryRetrievalService`, `BoardDetailsRetrievalService`에서, 작성자의 정보를 currentMemberInfo로 받는 것에서 해당 글의 작성자가 되도록 수정했습니다.

## Tasks

- `BoardRetrievalService` 수정
- `DeletedBoardsRetrievalService` 수정
- `BoardsByCategoryRetrievalService` 수정
- `BoardDetailsRetrievalService` 수정

## ETC


## Screenshot

- 게시글 목록, 커뮤니티 별 게시글 목록, 삭제된 게시글 목록 조회
![스크린샷 2024-07-22 125709](https://github.com/user-attachments/assets/26563105-977a-41dd-bab2-cfafe4a5525c)

- 게시글 상세 내용 조회
![스크린샷 2024-07-22 144117](https://github.com/user-attachments/assets/e3a4ce65-1f19-47b2-b299-89841ece6892)

