### PR TITLE
Cache-Control 설정을 통한 파일 캐싱 최적화 완료

### DIFF
--- a/src/main/java/page/clab/api/global/config/WebConfig.java
+++ b/src/main/java/page/clab/api/global/config/WebConfig.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
+import org.springframework.http.CacheControl;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
@@ -18,6 +19,7 @@ import page.clab.api.global.util.HtmlCharacterEscapes;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.time.Duration;
 
 @Configuration
 @RequiredArgsConstructor
@@ -36,9 +38,14 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         log.info("Resource UploadedFile Mapped : {} -> {}", fileURL, filePath);
+        CacheControl cacheControl = CacheControl.maxAge(Duration.ofDays(1))
+                .mustRevalidate()
+                .cachePrivate();
+
         registry
                 .addResourceHandler(fileURL + "/**")
                 .addResourceLocations("file://" + filePath + "/")
+                .setCacheControl(cacheControl)
                 .resourceChain(true)
                 .addResolver(new PathResourceResolver() {
                     @Override


### PR DESCRIPTION
## Summary

> #431 

이 PR은 Cache-Control 설정을 추가하여 서버에서 제공하는 파일의 캐싱을 최적화하는 작업을 포함합니다. 이를 통해 파일 접근 시 성능을 향상시키고, 불필요한 서버 요청을 줄여 서버 부하를 감소시킵니다.

## Tasks

- WebConfig 클래스에 Cache-Control 설정 추가
- 응답 헤더에 Cache-Control 설정이 적용되었는지 확인
- 캐시가 설정된 파일에 접근하여 성능 최적화 확인

## Screenshot

![image](https://github.com/user-attachments/assets/17b877c4-61ff-4fba-a879-6097cfb6107c)
![image](https://github.com/user-attachments/assets/e1ca3f95-fc54-4e44-b4c4-e3635b0cb3a4)
![image](https://github.com/user-attachments/assets/0af00eb7-c6f3-4117-bb77-6e312f5ab7fa)

## Log

```
2024-07-27 16:59:14.151 [http-nio-8080-exec-1] INFO  p.c.a.g.h.ApiLoggingInterceptor - [0:0:0:0:0:0:0:1:anonymousUser] /resources/files/profiles/202310000/1255299469048375_896b6bd5-8fb7-4e76-ac93-2a42aac385b4.jpg GET 200 7ms
2024-07-27 16:59:14.266 [http-nio-8080-exec-4] INFO  p.c.a.g.h.ApiLoggingInterceptor - [0:0:0:0:0:0:0:1:anonymousUser] /resources/files/profiles/202310000/1255299469048375_896b6bd5-8fb7-4e76-ac93-2a42aac385b4.jpg GET 200 4ms
2024-07-27 16:59:19.600 [http-nio-8080-exec-5] INFO  p.c.a.g.h.ApiLoggingInterceptor - [0:0:0:0:0:0:0:1:anonymousUser] /resources/files/profiles/202310000/1255299469048375_896b6bd5-8fb7-4e76-ac93-2a42aac385b4.jpg GET 304 0ms
2024-07-27 16:59:21.561 [http-nio-8080-exec-7] INFO  p.c.a.g.h.ApiLoggingInterceptor - [0:0:0:0:0:0:0:1:anonymousUser] /resources/files/profiles/202310000/1255299469048375_896b6bd5-8fb7-4e76-ac93-2a42aac385b4.jpg GET 304 1ms
```