### PR TITLE
업로드 파일 정보를 가져오지 못하는 오류 수정

### DIFF
--- a/src/main/java/page/clab/api/global/common/file/domain/UploadedFile.java
+++ b/src/main/java/page/clab/api/global/common/file/domain/UploadedFile.java
@@ -27,7 +27,7 @@ public class UploadedFile extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(name = "member_id", nullable = false)
     private String uploader;
 
     @Column(nullable = false)


### PR DESCRIPTION
## Summary

> #433 

- 업로드 파일 정보를 가져오지 못하는 오류를 해결합니다.
- 특정 API 호출 시 발생하는 SQL 오류를 수정합니다.

## Tasks

- uploaded_file 테이블에 member_id 컬럼 정보 추가