### PR TITLE
'io.jsonwebtoken ' 0.12.x 업데이트에 따른 JWT 생성 및 파싱 로직 마이그레이션 완료

### DIFF
--- a/src/main/java/page/clab/api/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/page/clab/api/global/auth/jwt/JwtTokenProvider.java
@@ -22,6 +22,7 @@ import page.clab.api.domain.auth.login.application.dto.response.TokenInfo;
 import page.clab.api.domain.memberManagement.member.domain.Role;
 import page.clab.api.global.auth.exception.TokenValidateException;
 
+import javax.crypto.SecretKey;
 import java.security.Key;
 import java.util.Arrays;
 import java.util.Collection;
@@ -49,20 +50,20 @@ public class JwtTokenProvider {
         Date expiry = new Date();
         Date accessTokenExpiry = new Date(expiry.getTime() + (accessTokenDuration));
         String accessToken = Jwts.builder()
-                .setSubject(id)
+                .subject(id)
                 .claim("role", role)
-                .setIssuedAt(expiry)
-                .setExpiration(accessTokenExpiry)
-                .signWith(key, SignatureAlgorithm.HS256)
+                .issuedAt(expiry)
+                .expiration(accessTokenExpiry)
+                .signWith(key)
                 .compact();
 
         Date refreshTokenExpiry = new Date(expiry.getTime() + (refreshTokenDuration));
         String refreshToken = Jwts.builder()
-                .setSubject(id)
+                .subject(id)
                 .claim("role", role)
-                .setIssuedAt(expiry)
-                .setExpiration(refreshTokenExpiry)
-                .signWith(key, SignatureAlgorithm.HS256)
+                .issuedAt(expiry)
+                .expiration(refreshTokenExpiry)
+                .signWith(key)
                 .compact();
 
         return TokenInfo.create(accessToken, refreshToken);
@@ -83,10 +84,8 @@ public class JwtTokenProvider {
         return false;
     }
 
-    public Authentication getAuthentication(String accessToken) {
-        Claims claims = parseClaims(accessToken);
-        log.debug("claims : {}", claims);
-        log.debug("accessToken : {}", accessToken);
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseClaims(token);
 
         if (claims.get("role") == null) {
             throw new TokenValidateException("권한 정보가 없는 토큰입니다.");
@@ -112,7 +111,10 @@ public class JwtTokenProvider {
 
     public boolean validateToken(String token) {
         try {
-            Jwts.parser().setSigningKey(key).build().parseClaimsJws(token);
+            Jwts.parser()
+                    .verifyWith((SecretKey) key)
+                    .build()
+                    .parseSignedClaims(token);
             return true;
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
             log.info("Invalid JWT Token");
@@ -128,16 +130,23 @@ public class JwtTokenProvider {
 
     public boolean validateTokenSilently(String token) {
         try {
-            Jwts.parser().setSigningKey(key).build().parseClaimsJws(token);
+            Jwts.parser()
+                    .verifyWith((SecretKey) key)
+                    .build()
+                    .parseSignedClaims(token);
             return true;
         } catch (Exception e) {
             return false;
         }
     }
 
-    public Claims parseClaims(String accessToken) {
+    public Claims parseClaims(String token) {
         try {
-            return Jwts.parser().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+            return Jwts.parser()
+                    .verifyWith((SecretKey) key)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
         } catch (ExpiredJwtException e) {
             return e.getClaims();
         }

--- a/src/main/java/page/clab/api/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/page/clab/api/global/auth/jwt/JwtTokenProvider.java
@@ -4,7 +4,6 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
@@ -51,7 +50,7 @@ public class JwtTokenProvider {
         Date accessTokenExpiry = new Date(expiry.getTime() + (accessTokenDuration));
         String accessToken = Jwts.builder()
                 .subject(id)
-                .claim("role", role)
+                .claim("role", role.getKey())
                 .issuedAt(expiry)
                 .expiration(accessTokenExpiry)
                 .signWith(key)
@@ -60,7 +59,7 @@ public class JwtTokenProvider {
         Date refreshTokenExpiry = new Date(expiry.getTime() + (refreshTokenDuration));
         String refreshToken = Jwts.builder()
                 .subject(id)
-                .claim("role", role)
+                .claim("role", role.getKey())
                 .issuedAt(expiry)
                 .expiration(refreshTokenExpiry)
                 .signWith(key)
@@ -93,7 +92,6 @@ public class JwtTokenProvider {
 
         Collection<? extends GrantedAuthority> authorities =
                 Arrays.stream(claims.get("role").toString().split(","))
-                        .map(this::formatRoleString)
                         .map(SimpleGrantedAuthority::new)
                         .toList();
 
@@ -150,12 +148,5 @@ public class JwtTokenProvider {
         } catch (ExpiredJwtException e) {
             return e.getClaims();
         }
-    }
-
-    private String formatRoleString(String role) {
-        if (!role.startsWith("ROLE_")) {
-            return "ROLE_" + role;
-        }
-        return role;
     }
 }

--- a/src/main/java/page/clab/api/global/config/SecurityConfig.java
+++ b/src/main/java/page/clab/api/global/config/SecurityConfig.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -40,7 +40,7 @@ import java.io.IOException;
 
 @Configuration
 @EnableWebSecurity
-@EnableGlobalMethodSecurity(securedEnabled = true)
+@EnableMethodSecurity(securedEnabled = true)
 @RequiredArgsConstructor
 @Slf4j
 public class SecurityConfig {


### PR DESCRIPTION
## Summary

> #450 

현재 'io.jsonwebtoken' 라이브러리가 0.12.x 버전으로 업데이트되면서 기존에 사용하던 JWT 생성 및 파싱 관련 메소드들이 Deprecate 되었습니다. 이에 따라 최신 버전에 맞춰 Deprecate된 로직을 마이그레이션합니다.

추가로, ROLE_ prefix 설정 로직을 개선합니다.

## Tasks

- Deprecate된 메소드 사용 부분을 새로운 메소드로 변경
- `ROLE_` prefix 설정 로직 개선

## ETC

[Java JWT: JSON Web Token for Java and Android](https://github.com/jwtk/jjwt)